### PR TITLE
Add comment overlay generator page

### DIFF
--- a/app/comment-overlay/CommentOverlayClient.tsx
+++ b/app/comment-overlay/CommentOverlayClient.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { useState, useRef } from 'react';
+import html2canvas from 'html2canvas';
+import { Download, Image as ImageIcon } from 'lucide-react';
+
+const CommentOverlayClient: React.FC = () => {
+  const [photo, setPhoto] = useState<string | null>(null);
+  const [text, setText] = useState('Tulis komentarmu di sini...');
+  const [date, setDate] = useState<string>(() => new Date().toISOString().split('T')[0]);
+  const [bgColor, setBgColor] = useState('#ffffff');
+  const bubbleRef = useRef<HTMLDivElement>(null);
+
+  const handlePhotoUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => setPhoto(ev.target?.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const downloadImage = async () => {
+    const node = bubbleRef.current;
+    if (!node) return;
+    const canvas = await html2canvas(node);
+    const link = document.createElement('a');
+    link.download = 'comment.png';
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+      {/* Controls */}
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Foto Profil</label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handlePhotoUpload}
+            className="block w-full text-sm text-gray-900 dark:text-gray-100 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-purple-50 file:text-purple-700 hover:file:bg-purple-100"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Teks Komentar</label>
+          <textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            className="w-full p-2 border rounded-md bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200"
+            rows={4}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Tanggal</label>
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            className="w-full p-2 border rounded-md bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">Warna Latar Bubble</label>
+          <input
+            type="color"
+            value={bgColor}
+            onChange={e => setBgColor(e.target.value)}
+            className="w-16 h-8 p-1 border rounded-md bg-white dark:bg-gray-800"
+          />
+        </div>
+        <button
+          onClick={downloadImage}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md text-sm"
+        >
+          <Download size={16} /> Unduh
+        </button>
+      </div>
+
+      {/* Preview */}
+      <div className="flex items-center justify-center">
+        <div
+          ref={bubbleRef}
+          className="flex items-start gap-3 p-3 rounded-xl shadow-lg max-w-sm"
+          style={{ backgroundColor: bgColor }}
+        >
+          {photo ? (
+            <img src={photo} alt="avatar" className="w-12 h-12 rounded-full object-cover" />
+          ) : (
+            <div className="w-12 h-12 rounded-full bg-gray-300 flex items-center justify-center text-gray-600">
+              <ImageIcon size={24} />
+            </div>
+          )}
+          <div className="flex flex-col">
+            <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{text}</p>
+            <span className="text-xs text-gray-500 mt-1">{date}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommentOverlayClient;

--- a/app/comment-overlay/page.tsx
+++ b/app/comment-overlay/page.tsx
@@ -1,0 +1,57 @@
+import CommentOverlayClient from './CommentOverlayClient';
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import ThemeToggle from '@/components/ThemeToggle';
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://ruangriung.my.id'),
+  title: 'Comment Overlay Generator - RuangRiung',
+  description: 'Buat bubble komentar yang dapat ditempelkan pada video dengan foto, teks, tanggal, dan warna kustom.',
+  keywords: ['comment overlay', 'bubble komentar', 'generator komentar', 'ruangriung'],
+  alternates: {
+    canonical: '/comment-overlay',
+  },
+  openGraph: {
+    title: 'Comment Overlay Generator - RuangRiung',
+    description: 'Buat bubble komentar yang dapat ditempelkan pada video dengan foto, teks, tanggal, dan warna kustom.',
+    url: 'https://ruangriung.my.id/comment-overlay',
+    siteName: 'RuangRiung AI Generator',
+    images: [
+      {
+        url: 'https://www.ruangriung.my.id/assets/ruangriung.png',
+        width: 1200,
+        height: 630,
+        alt: 'RuangRiung Comment Overlay',
+      },
+    ],
+    locale: 'id_ID',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Comment Overlay Generator - RuangRiung',
+    description: 'Buat bubble komentar yang dapat ditempelkan pada video dengan foto, teks, tanggal, dan warna kustom.',
+    images: ['https://www.ruangriung.my.id/assets/ruangriung.png'],
+  },
+};
+
+export default function CommentOverlayPage() {
+  return (
+    <div className="container mx-auto p-4 md:p-8">
+      <div className="mb-4 flex justify-between items-center">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-light-bg dark:bg-dark-bg rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset text-gray-700 dark:text-gray-300 hover:text-purple-600 transition-colors text-sm font-semibold"
+          aria-label="Kembali ke Beranda"
+        >
+          <ArrowLeft size={16} />
+          <span>Kembali ke Beranda</span>
+        </Link>
+        <ThemeToggle />
+      </div>
+      <h1 className="text-3xl md:text-4xl font-bold text-center text-gray-800 dark:text-gray-200 mb-8">Generator Bubble Komentar</h1>
+      <CommentOverlayClient />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add comment overlay generator page with SEO metadata and theme toggle
- implement client tool to upload photo, text, date, and bubble color, and download as image

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint? https://nextjs.org/docs/basic-features/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c59b0b4832eac6ad95ddcd2f998