### PR TITLE
feat: show newest prompts first

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -38,7 +38,7 @@ export async function getAllPrompts(): Promise<Prompt[]> {
           return prompt;
         })
     );
-    return allPrompts;
+    return allPrompts.sort((a, b) => Number(b.id) - Number(a.id));
   } catch (error) {
     // If the directory doesn't exist, return an empty array
     console.log("Could not read prompts directory, returning empty array.");


### PR DESCRIPTION
## Summary
- sort prompt files by ID so the latest entries show first in prompt collection

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b36c32a1a4832ebae417e4aa278aa0