### PR TITLE
Add date metadata to prompts

### DIFF
--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -97,7 +97,8 @@ export default function PromptClient({ prompts }: PromptClientProps) {
           <Link key={prompt.id} href={`/kumpulan-prompt/${prompt.slug}`}>
             <div className="block h-full p-6 bg-white border border-gray-200 rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-700">
               <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{prompt.title}</h5>
-              <p className="font-normal text-gray-500 dark:text-gray-400 mb-3">Oleh: {prompt.author}</p>
+              <p className="font-normal text-gray-500 dark:text-gray-400">Oleh: {prompt.author}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
               <p className="font-normal text-gray-600 dark:text-gray-300 mb-4">Tool: <strong>{prompt.tool}</strong></p>
               <div className="flex flex-wrap gap-2">
                 {prompt.tags.map(tag => (

--- a/app/kumpulan-prompt/[slug]/page.tsx
+++ b/app/kumpulan-prompt/[slug]/page.tsx
@@ -36,7 +36,8 @@ export default async function PromptDetailPage({ params }: { params: { slug: str
           </div>
         )}
         <h1 className="text-4xl font-bold mb-4 text-gray-900 dark:text-white">{prompt.title}</h1>
-        <p className="text-lg text-gray-600 dark:text-gray-300 mb-2">By {prompt.author}</p>
+        <p className="text-lg text-gray-600 dark:text-gray-300">By {prompt.author}</p>
+        <p className="text-md text-gray-500 dark:text-gray-400 mb-2">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
         <p className="text-md text-gray-500 dark:text-gray-400 mb-6">Tool: {prompt.tool}</p>
         
         <div className="prose prose-lg max-w-none dark:prose-invert">

--- a/content/prompts/prompt-1.md
+++ b/content/prompts/prompt-1.md
@@ -3,6 +3,7 @@ id: "1"
 slug: "prompt-satu-keren"
 title: "Prompt Keren Pertama"
 author: "Ayick"
+date: "2025-08-30"
 tool: "DALL-E 3"
 tags:
   - fantasi

--- a/content/prompts/prompt-2.md
+++ b/content/prompts/prompt-2.md
@@ -3,6 +3,7 @@ id: "2"
 slug: "prompt-kedua-hebat"
 title: "Prompt Hebat Kedua"
 author: "Budi"
+date: "2025-08-30"
 tool: "Midjourney"
 tags:
   - sci-fi

--- a/content/prompts/prompt-3.md
+++ b/content/prompts/prompt-3.md
@@ -3,6 +3,7 @@ id: "3"
 slug: "ilustrasi-sunrise-desa"
 title: "Ilustrasi Sunrise di Desa"
 author: "Citra"
+date: "2025-08-30"
 tool: "Stable Diffusion"
 tags:
   - ilustrasi

--- a/content/prompts/prompt-4.md
+++ b/content/prompts/prompt-4.md
@@ -3,6 +3,7 @@ id: "4"
 slug: "potret-realistik-nenek"
 title: "Potret Realistik Nenek"
 author: "Dewi"
+date: "2025-08-30"
 tool: "Midjourney"
 tags:
   - potret

--- a/content/prompts/prompt-5.md
+++ b/content/prompts/prompt-5.md
@@ -3,6 +3,7 @@ id: "5"
 slug: "arsitektur-ramah-lingkungan"
 title: "Arsitektur Ramah Lingkungan"
 author: "Eko"
+date: "2025-08-30"
 tool: "DALL-E 3"
 tags:
   - arsitektur

--- a/content/prompts/prompt-6.md
+++ b/content/prompts/prompt-6.md
@@ -3,6 +3,7 @@ id: "6"
 slug: "wajah-energi-kontras"
 title: "Wajah Energi Kontras"
 author: "Arif Tirtana"
+date: "2025-08-30"
 tool: "Gemini"
 tags:
   - seni digital

--- a/content/prompts/prompt-7.md
+++ b/content/prompts/prompt-7.md
@@ -3,6 +3,7 @@ id: "7"
 slug: "bunga-rumput"
 title: "Bunga Rumput"
 author: "awanbyru"
+date: "2025-08-30"
 tool: "Gemini"
 tags:
   - fractal

--- a/content/prompts/prompt-8.md
+++ b/content/prompts/prompt-8.md
@@ -3,6 +3,7 @@ id: "8"
 slug: "cubist-surealist"
 title: "Surealis Cubism"
 author: "Geo storm"
+date: "2025-08-30"
 tool: "Gemini, ChatGpt, etc"
 tags:
   - cubism

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -9,6 +9,7 @@ export interface Prompt {
   slug: string;
   title: string;
   author: string;
+  date: string;
   tool: string;
   image?: string;
   tags: string[];
@@ -31,6 +32,7 @@ export async function getAllPrompts(): Promise<Prompt[]> {
             image: data.image,
             title: data.title,
             author: data.author,
+            date: data.date,
             tool: data.tool,
             tags: data.tags || [],
             promptContent: content.trim(),


### PR DESCRIPTION
## Summary
- parse `date` field from prompt front matter
- show prompt date on list and detail pages

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fc11714832ea946fe2713c01b8f