### PR TITLE
Add copy buttons and sequential prompt dates

### DIFF
--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -8,6 +8,7 @@ import PromptSubmissionForm from '../../components/PromptSubmissionForm';
 import Pagination from '../../components/Pagination';
 import AdBanner from '../../components/AdBanner';
 import { ArrowLeft } from 'lucide-react';
+import CopyButton from '../../components/CopyButton';
 
 const PROMPTS_PER_PAGE = 9;
 
@@ -94,18 +95,32 @@ export default function PromptClient({ prompts }: PromptClientProps) {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {paginatedPrompts.map((prompt: Prompt) => (
-          <Link key={prompt.id} href={`/kumpulan-prompt/${prompt.slug}`}>
-            <div className="block h-full p-6 bg-white border border-gray-200 rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-700">
-              <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{prompt.title}</h5>
-              <p className="font-normal text-gray-500 dark:text-gray-400 mb-3">Oleh: {prompt.author}</p>
-              <p className="font-normal text-gray-600 dark:text-gray-300 mb-4">Tool: <strong>{prompt.tool}</strong></p>
-              <div className="flex flex-wrap gap-2">
-                {prompt.tags.map(tag => (
-                  <span key={tag} className="inline-block bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-0.5 rounded-full dark:bg-blue-900 dark:text-blue-300">{tag}</span>
-                ))}
-              </div>
+          <div
+            key={prompt.id}
+            className="h-full p-6 bg-white border border-gray-200 rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-700"
+          >
+            <Link href={`/kumpulan-prompt/${prompt.slug}`}>
+              <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white hover:underline">
+                {prompt.title}
+              </h5>
+            </Link>
+            <p className="font-normal text-gray-500 dark:text-gray-400">Oleh: {prompt.author}</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
+            <p className="font-normal text-gray-600 dark:text-gray-300 mb-4">
+              Tool: <strong>{prompt.tool}</strong>
+            </p>
+            <div className="flex flex-wrap gap-2 mb-4">
+              {prompt.tags.map(tag => (
+                <span
+                  key={tag}
+                  className="inline-block bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-0.5 rounded-full dark:bg-blue-900 dark:text-blue-300"
+                >
+                  {tag}
+                </span>
+              ))}
             </div>
-          </Link>
+            <CopyButton text={prompt.promptContent} />
+          </div>
         ))}
       </div>
 

--- a/app/kumpulan-prompt/[slug]/page.tsx
+++ b/app/kumpulan-prompt/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import AdBanner from '@/components/AdBanner';
+import CopyButton from '@/components/CopyButton';
 
 export default async function PromptDetailPage({ params }: { params: { slug: string } }) {
   const prompt = await getPromptBySlug(params.slug);
@@ -36,11 +37,16 @@ export default async function PromptDetailPage({ params }: { params: { slug: str
           </div>
         )}
         <h1 className="text-4xl font-bold mb-4 text-gray-900 dark:text-white">{prompt.title}</h1>
-        <p className="text-lg text-gray-600 dark:text-gray-300 mb-2">By {prompt.author}</p>
+        <p className="text-lg text-gray-600 dark:text-gray-300">By {prompt.author}</p>
+        <p className="text-md text-gray-500 dark:text-gray-400 mb-2">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
         <p className="text-md text-gray-500 dark:text-gray-400 mb-6">Tool: {prompt.tool}</p>
         
         <div className="prose prose-lg max-w-none dark:prose-invert">
           <p>{prompt.promptContent}</p>
+        </div>
+
+        <div className="mt-4">
+          <CopyButton text={prompt.promptContent} />
         </div>
 
         <div className="my-8">

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyButtonProps {
+  text: string;
+}
+
+export default function CopyButton({ text }: CopyButtonProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text:', err);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={`inline-flex items-center px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-gray-200 font-semibold rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all ${isCopied ? '!bg-green-200 text-green-700' : ''} hover:bg-gray-400 dark:hover:bg-gray-600`}
+    >
+      {isCopied ? <Check size={16} className="mr-2" /> : <Copy size={16} className="mr-2" />}
+      {isCopied ? 'Tersalin!' : 'Salin Prompt'}
+    </button>
+  );
+}
+

--- a/content/prompts/prompt-1.md
+++ b/content/prompts/prompt-1.md
@@ -3,6 +3,7 @@ id: "1"
 slug: "prompt-satu-keren"
 title: "Prompt Keren Pertama"
 author: "Ayick"
+date: "2025-08-23"
 tool: "DALL-E 3"
 tags:
   - fantasi

--- a/content/prompts/prompt-2.md
+++ b/content/prompts/prompt-2.md
@@ -3,6 +3,7 @@ id: "2"
 slug: "prompt-kedua-hebat"
 title: "Prompt Hebat Kedua"
 author: "Budi"
+date: "2025-08-24"
 tool: "Midjourney"
 tags:
   - sci-fi

--- a/content/prompts/prompt-3.md
+++ b/content/prompts/prompt-3.md
@@ -3,6 +3,7 @@ id: "3"
 slug: "ilustrasi-sunrise-desa"
 title: "Ilustrasi Sunrise di Desa"
 author: "Citra"
+date: "2025-08-25"
 tool: "Stable Diffusion"
 tags:
   - ilustrasi

--- a/content/prompts/prompt-4.md
+++ b/content/prompts/prompt-4.md
@@ -3,6 +3,7 @@ id: "4"
 slug: "potret-realistik-nenek"
 title: "Potret Realistik Nenek"
 author: "Dewi"
+date: "2025-08-26"
 tool: "Midjourney"
 tags:
   - potret

--- a/content/prompts/prompt-5.md
+++ b/content/prompts/prompt-5.md
@@ -3,6 +3,7 @@ id: "5"
 slug: "arsitektur-ramah-lingkungan"
 title: "Arsitektur Ramah Lingkungan"
 author: "Eko"
+date: "2025-08-27"
 tool: "DALL-E 3"
 tags:
   - arsitektur

--- a/content/prompts/prompt-6.md
+++ b/content/prompts/prompt-6.md
@@ -3,6 +3,7 @@ id: "6"
 slug: "wajah-energi-kontras"
 title: "Wajah Energi Kontras"
 author: "Arif Tirtana"
+date: "2025-08-28"
 tool: "Gemini"
 tags:
   - seni digital

--- a/content/prompts/prompt-7.md
+++ b/content/prompts/prompt-7.md
@@ -3,6 +3,7 @@ id: "7"
 slug: "bunga-rumput"
 title: "Bunga Rumput"
 author: "awanbyru"
+date: "2025-08-29"
 tool: "Gemini"
 tags:
   - fractal

--- a/content/prompts/prompt-8.md
+++ b/content/prompts/prompt-8.md
@@ -3,6 +3,7 @@ id: "8"
 slug: "cubist-surealist"
 title: "Surealis Cubism"
 author: "Geo storm"
+date: "2025-08-30"
 tool: "Gemini, ChatGpt, etc"
 tags:
   - cubism

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -9,6 +9,7 @@ export interface Prompt {
   slug: string;
   title: string;
   author: string;
+  date: string;
   tool: string;
   image?: string;
   tags: string[];
@@ -31,6 +32,7 @@ export async function getAllPrompts(): Promise<Prompt[]> {
             image: data.image,
             title: data.title,
             author: data.author,
+            date: data.date,
             tool: data.tool,
             tags: data.tags || [],
             promptContent: content.trim(),


### PR DESCRIPTION
## Summary
- add reusable CopyButton component
- show copy buttons on prompt list and detail pages
- assign sequential dates to prompt files

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch `Inter` font)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fc11714832ea946fe2713c01b8f