### PR TITLE
feat: add copy button to prompt detail page

### DIFF
--- a/app/kumpulan-prompt/[slug]/page.tsx
+++ b/app/kumpulan-prompt/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import AdBanner from '@/components/AdBanner';
+import CopyButton from '@/components/CopyButton';
 
 export default async function PromptDetailPage({ params }: { params: { slug: string } }) {
   const prompt = await getPromptBySlug(params.slug);
@@ -39,7 +40,10 @@ export default async function PromptDetailPage({ params }: { params: { slug: str
         <p className="text-lg text-gray-600 dark:text-gray-300">By {prompt.author}</p>
         <p className="text-md text-gray-500 dark:text-gray-400 mb-2">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
         <p className="text-md text-gray-500 dark:text-gray-400 mb-6">Tool: {prompt.tool}</p>
-        
+
+        <div className="mb-4 flex justify-end">
+          <CopyButton text={prompt.promptContent} />
+        </div>
         <div className="prose prose-lg max-w-none dark:prose-invert">
           <p>{prompt.promptContent}</p>
         </div>

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyButtonProps {
+  text: string;
+}
+
+export default function CopyButton({ text }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text:', err);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="inline-flex items-center px-3 py-1 text-sm text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded hover:bg-gray-300 dark:hover:bg-gray-600"
+    >
+      {copied ? <Check size={16} /> : <Copy size={16} />}
+      <span className="ml-2">{copied ? 'Disalin' : 'Salin'}</span>
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable copy button component
- show copy button on prompt detail page for easy copying

## Testing
- `pnpm lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa537cb58832eb38b348611381e9e