### PR TITLE
Add urban-themed prompt

### DIFF
--- a/content/prompts/prompt-17.md
+++ b/content/prompts/prompt-17.md
@@ -1,0 +1,16 @@
+---
+id: "17"
+slug: "urban-themed"
+title: "Urban-themed"
+author: "Adie Setyadi"
+date: "2025-09-09"
+tool: "Gemini"
+tags:
+  - urban
+  - fashion
+  - street photography
+  - lifestyle
+---
+
+A full-body shot captures a young woman with long, flowing dark brown hair as she descends a set of concrete stairs outdoors. She is wearing a maroon long-sleeved sweatshirt, light brown fitted pants, and black and white low-top sneakers. A cream-colored crossbody bag with a wide white strap rests on her left hip. She is also wearing a watch on her left wrist and a delicate necklace. Her gaze is directed slightly off-camera to her right, and she has a subtle, pleasant expression.
+The background reveals a serene outdoor setting. Behind her is a calm body of water, reflecting the soft light of either dawn or dusk. Several tall, light-colored buildings stand in the distance beyond the water, partially obscured by trees. Lush green foliage and pink flowers line the sides of the stairs, adding a touch of nature to the urban backdrop. Rasio 9:16


### PR DESCRIPTION
## Summary
- add "Urban-themed" prompt by Adie Setyadi for Gemini

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbcd942f4832ea84c667d678e28c5