### PR TITLE
feat: add optional facebook link to prompt submissions

### DIFF
--- a/app/api/submit-prompt/route.ts
+++ b/app/api/submit-prompt/route.ts
@@ -4,7 +4,7 @@ import nodemailer from 'nodemailer';
 
 export async function POST(request: Request) {
   try {
-    const { author, email, title, promptContent, tool, tags, token } = await request.json();
+    const { author, email, facebook, title, promptContent, tool, tags, token } = await request.json();
 
     if (!author || !email || !title || !promptContent || !tool || !token) {
       return NextResponse.json(
@@ -54,6 +54,7 @@ export async function POST(request: Request) {
         <h2>Submission Prompt Baru</h2>
         <p><strong>Nama Pengirim:</strong> ${author}</p>
         <p><strong>Email Pengirim:</strong> ${email}</p>
+        <p><strong>Link Facebook:</strong> ${facebook || '-'}</p>
         <p><strong>Judul Prompt:</strong> ${title}</p>
         <p><strong>Tool:</strong> ${tool}</p>
         <p><strong>Tags:</strong> ${tags.join(', ')}</p>

--- a/components/PromptSubmissionForm.tsx
+++ b/components/PromptSubmissionForm.tsx
@@ -23,6 +23,7 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
   const [promptContent, setPromptContent] = useState('');
   const [tool, setTool] = useState('');
   const [tags, setTags] = useState('');
+  const [facebook, setFacebook] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<'success' | 'error' | null>(null);
   const [token, setToken] = useState('');
@@ -46,6 +47,7 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
       body: JSON.stringify({
         author,
         email,
+        facebook,
         title,
         promptContent,
         tool,
@@ -60,6 +62,7 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
       setSubmitStatus('success');
       setAuthor('');
       setEmail('');
+      setFacebook('');
       setTitle('');
       setPromptContent('');
       setTool('');
@@ -87,6 +90,13 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
               <input type="text" placeholder="Nama Anda" value={author} onChange={e => setAuthor(e.target.value)} required className="p-2 border rounded dark:bg-gray-700" />
               <input type="email" placeholder="Email Anda" value={email} onChange={e => setEmail(e.target.value)} required className="p-2 border rounded dark:bg-gray-700" />
             </div>
+            <input
+              type="url"
+              placeholder="Link Facebook (opsional)"
+              value={facebook}
+              onChange={e => setFacebook(e.target.value)}
+              className="w-full p-2 border rounded mb-4 dark:bg-gray-700"
+            />
             <input type="text" placeholder="Judul Prompt" value={title} onChange={e => setTitle(e.target.value)} required className="w-full p-2 border rounded mb-4 dark:bg-gray-700" />
             <textarea placeholder="Isi Prompt" value={promptContent} onChange={e => setPromptContent(e.target.value)} required rows={6} className="w-full p-2 border rounded mb-4 dark:bg-gray-700"></textarea>
             <input type="text" placeholder="Tool yang Digunakan (e.g., DALL-E 3)" value={tool} onChange={e => setTool(e.target.value)} required className="w-full p-2 border rounded mb-4 dark:bg-gray-700" />


### PR DESCRIPTION
## Summary
- allow users to submit an optional Facebook profile link with prompts
- forward Facebook links to the submit-prompt API email notification

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c60b3e3f18832e84f1b1829aacc179