### PR TITLE
feat: add hybrids psychedelic prompt

### DIFF
--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -97,7 +97,21 @@ export default function PromptClient({ prompts }: PromptClientProps) {
           <Link key={prompt.id} href={`/kumpulan-prompt/${prompt.slug}`}>
             <div className="block h-full p-6 bg-white border border-gray-200 rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-700">
               <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{prompt.title}</h5>
-              <p className="font-normal text-gray-500 dark:text-gray-400">Oleh: {prompt.author}</p>
+              <p className="font-normal text-gray-500 dark:text-gray-400">
+                Oleh:{' '}
+                {prompt.facebook ? (
+                  <a
+                    href={prompt.facebook}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    {prompt.author}
+                  </a>
+                ) : (
+                  prompt.author
+                )}
+              </p>
               <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
               <p className="font-normal text-gray-600 dark:text-gray-300 mb-4">Tool: <strong>{prompt.tool}</strong></p>
               <div className="flex flex-wrap gap-2">

--- a/app/kumpulan-prompt/[slug]/page.tsx
+++ b/app/kumpulan-prompt/[slug]/page.tsx
@@ -37,7 +37,21 @@ export default async function PromptDetailPage({ params }: { params: { slug: str
           </div>
         )}
         <h1 className="text-4xl font-bold mb-4 text-gray-900 dark:text-white">{prompt.title}</h1>
-        <p className="text-lg text-gray-600 dark:text-gray-300">By {prompt.author}</p>
+        <p className="text-lg text-gray-600 dark:text-gray-300">
+          By{' '}
+          {prompt.facebook ? (
+            <a
+              href={prompt.facebook}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              {prompt.author}
+            </a>
+          ) : (
+            prompt.author
+          )}
+        </p>
         <p className="text-md text-gray-500 dark:text-gray-400 mb-2">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
         <p className="text-md text-gray-500 dark:text-gray-400 mb-6">Tool: {prompt.tool}</p>
 

--- a/content/prompts/prompt-72.md
+++ b/content/prompts/prompt-72.md
@@ -1,0 +1,16 @@
+---
+id: "72"
+slug: "hybrids-psychedelic"
+title: "Hybrids Psychedelic"
+author: "Arif Tirtana"
+email: "ayicktigabelas@gmail.com"
+facebook: "https://www.facebook.com/ayicktigabelas"
+date: "2025-09-14"
+tool: "DALL-E 3"
+tags:
+  - Hybrida
+  - psikedelik
+  - Bali
+---
+
+Seni hibrida psikedelik warna neon tetesan asam, pastel color, checker board gambar gaya gotik Mimpi Buruk dengan kelelawar dan gagak, patung leak Bali, dan efek cahaya misterius, rasio 9:16

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -9,6 +9,8 @@ export interface Prompt {
   slug: string;
   title: string;
   author: string;
+  email?: string;
+  facebook?: string;
   date: string;
   tool: string;
   image?: string;
@@ -32,6 +34,8 @@ export async function getAllPrompts(): Promise<Prompt[]> {
             image: data.image,
             title: data.title,
             author: data.author,
+            email: data.email,
+            facebook: data.facebook,
             date: data.date,
             tool: data.tool,
             tags: data.tags || [],


### PR DESCRIPTION
## Summary
- support optional email and facebook fields for prompts
- display author facebook links in prompt listings and details
- add "Hybrids Psychedelic" prompt entry

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c6101fec8c832ebd90a99390f69916