### PR TITLE
feat: add optional link field to prompt submissions

### DIFF
--- a/app/api/submit-prompt/route.ts
+++ b/app/api/submit-prompt/route.ts
@@ -4,7 +4,7 @@ import nodemailer from 'nodemailer';
 
 export async function POST(request: Request) {
   try {
-    const { author, email, facebook, title, promptContent, tool, tags, token } = await request.json();
+    const { author, email, facebook, link, title, promptContent, tool, tags, token } = await request.json();
 
     if (!author || !email || !title || !promptContent || !tool || !token) {
       return NextResponse.json(
@@ -55,6 +55,7 @@ export async function POST(request: Request) {
         <p><strong>Nama Pengirim:</strong> ${author}</p>
         <p><strong>Email Pengirim:</strong> ${email}</p>
         <p><strong>Link Facebook:</strong> ${facebook || '-'}</p>
+        <p><strong>Link:</strong> ${link || '-'}</p>
         <p><strong>Judul Prompt:</strong> ${title}</p>
         <p><strong>Tool:</strong> ${tool}</p>
         <p><strong>Tags:</strong> ${tags.join(', ')}</p>

--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -99,9 +99,9 @@ export default function PromptClient({ prompts }: PromptClientProps) {
               <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{prompt.title}</h5>
               <p className="font-normal text-gray-500 dark:text-gray-400">
                 Oleh:{' '}
-                {prompt.facebook ? (
+                {prompt.link || prompt.facebook ? (
                   <a
-                    href={prompt.facebook}
+                    href={prompt.link || prompt.facebook}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:underline"

--- a/app/kumpulan-prompt/[slug]/page.tsx
+++ b/app/kumpulan-prompt/[slug]/page.tsx
@@ -39,9 +39,9 @@ export default async function PromptDetailPage({ params }: { params: { slug: str
         <h1 className="text-4xl font-bold mb-4 text-gray-900 dark:text-white">{prompt.title}</h1>
         <p className="text-lg text-gray-600 dark:text-gray-300">
           By{' '}
-          {prompt.facebook ? (
+          {prompt.link || prompt.facebook ? (
             <a
-              href={prompt.facebook}
+              href={prompt.link || prompt.facebook}
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline"

--- a/components/PromptSubmissionForm.tsx
+++ b/components/PromptSubmissionForm.tsx
@@ -24,6 +24,7 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
   const [tool, setTool] = useState('');
   const [tags, setTags] = useState('');
   const [facebook, setFacebook] = useState('');
+  const [link, setLink] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<'success' | 'error' | null>(null);
   const [token, setToken] = useState('');
@@ -48,6 +49,7 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
         author,
         email,
         facebook,
+        link,
         title,
         promptContent,
         tool,
@@ -63,6 +65,7 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
       setAuthor('');
       setEmail('');
       setFacebook('');
+      setLink('');
       setTitle('');
       setPromptContent('');
       setTool('');
@@ -95,6 +98,13 @@ export default function PromptSubmissionForm({ isOpen, onClose }: PromptSubmissi
               placeholder="Link Facebook (opsional)"
               value={facebook}
               onChange={e => setFacebook(e.target.value)}
+              className="w-full p-2 border rounded mb-4 dark:bg-gray-700"
+            />
+            <input
+              type="url"
+              placeholder="Link (opsional)"
+              value={link}
+              onChange={e => setLink(e.target.value)}
               className="w-full p-2 border rounded mb-4 dark:bg-gray-700"
             />
             <input type="text" placeholder="Judul Prompt" value={title} onChange={e => setTitle(e.target.value)} required className="w-full p-2 border rounded mb-4 dark:bg-gray-700" />

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -11,6 +11,7 @@ export interface Prompt {
   author: string;
   email?: string;
   facebook?: string;
+  link?: string;
   date: string;
   tool: string;
   image?: string;
@@ -36,6 +37,7 @@ export async function getAllPrompts(): Promise<Prompt[]> {
             author: data.author,
             email: data.email,
             facebook: data.facebook,
+            link: data.link,
             date: data.date,
             tool: data.tool,
             tags: data.tags || [],


### PR DESCRIPTION
## Summary
- add optional generic link field to prompt submission form
- parse and display submitted links for prompts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6295f5438832ea91a7f4a38507e1f