### PR TITLE
Add related prompts section on detail page

### DIFF
--- a/app/kumpulan-prompt/[slug]/page.tsx
+++ b/app/kumpulan-prompt/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getPromptBySlug } from '../../../lib/prompts';
+import { getAllPrompts } from '../../../lib/prompts';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
@@ -6,11 +6,26 @@ import AdBanner from '@/components/AdBanner';
 import CopyButton from '@/components/CopyButton';
 
 export default async function PromptDetailPage({ params }: { params: { slug: string } }) {
-  const prompt = await getPromptBySlug(params.slug);
+  const prompts = await getAllPrompts();
+  const prompt = prompts.find(currentPrompt => currentPrompt.slug === params.slug);
 
   if (!prompt) {
     notFound();
   }
+
+  const relatedPrompts = prompts
+    .filter(related => {
+      if (related.slug === prompt.slug) {
+        return false;
+      }
+
+      if (!related.tags.length || !prompt.tags.length) {
+        return false;
+      }
+
+      return related.tags.some(tag => prompt.tags.includes(tag));
+    })
+    .slice(0, 4);
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -69,6 +84,68 @@ export default async function PromptDetailPage({ params }: { params: { slug: str
         <div className="prose prose-lg max-w-none dark:prose-invert">
           <p>{prompt.promptContent}</p>
         </div>
+
+        {relatedPrompts.length > 0 && (
+          <div className="mt-10">
+            <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">Prompt Terkait</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {relatedPrompts.map(relatedPrompt => (
+                <Link
+                  key={relatedPrompt.slug}
+                  href={`/kumpulan-prompt/${relatedPrompt.slug}`}
+                  className="block h-full"
+                >
+                  <div className="h-full p-5 bg-gray-50 border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300 dark:bg-gray-900 dark:border-gray-700">
+                    <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+                      {relatedPrompt.title}
+                    </h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      Oleh{' '}
+                      {relatedPrompt.link || relatedPrompt.facebook ? (
+                        <a
+                          href={relatedPrompt.link || relatedPrompt.facebook}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:underline"
+                        >
+                          {relatedPrompt.author}
+                        </a>
+                      ) : (
+                        relatedPrompt.author
+                      )}
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+                      Tool:{' '}
+                      <span className="font-semibold text-gray-700 dark:text-gray-300">
+                        {relatedPrompt.tool}
+                      </span>
+                    </p>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      {relatedPrompt.promptContent.length > 120
+                        ? `${relatedPrompt.promptContent.slice(0, 120)}...`
+                        : relatedPrompt.promptContent}
+                    </p>
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {relatedPrompt.tags.slice(0, 3).map(tag => (
+                        <span
+                          key={tag}
+                          className="inline-block bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-0.5 rounded-full dark:bg-blue-900 dark:text-blue-300"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                      {relatedPrompt.tags.length > 3 && (
+                        <span className="inline-block bg-gray-200 text-gray-700 text-xs font-semibold px-2.5 py-0.5 rounded-full dark:bg-gray-700 dark:text-gray-300">
+                          +{relatedPrompt.tags.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="my-8">
           <AdBanner dataAdSlot="5961316189" />


### PR DESCRIPTION
## Summary
- load prompt data from all entries in the detail page to identify related prompts by shared tags
- render a related prompts grid beneath each prompt's content so readers can jump to similar ideas

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c84bc1a76c832e95727ad4415d9179