### PR TITLE
Fix textarea modal state synchronization

### DIFF
--- a/components/TextareaModal.tsx
+++ b/components/TextareaModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Check, X } from 'lucide-react';
 
 interface TextareaModalProps {
@@ -14,6 +14,12 @@ interface TextareaModalProps {
 
 export default function TextareaModal({ isOpen, onClose, value, onChange, title, readOnly = false }: TextareaModalProps) {
   const [internalValue, setInternalValue] = useState(value);
+
+  useEffect(() => {
+    if (isOpen) {
+      setInternalValue(value);
+    }
+  }, [isOpen, value]);
 
   if (!isOpen) return null;
 


### PR DESCRIPTION
## Summary
- ensure the textarea modal updates its internal value from the latest prop when opened so zoomed prompts reflect current text

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9587bb4e0832ea76b419807481e04