### PR TITLE
Fix Battle Ignite qualification themes

### DIFF
--- a/app/battle-ignite-friendship/page.tsx
+++ b/app/battle-ignite-friendship/page.tsx
@@ -209,32 +209,32 @@ const qualificationBattles = [
   },
   {
     id: 3,
-    theme: 'Refraction labyrinth',
+    theme: 'Hypervoronoi Matrix',
     left: withParticipant('Bangteh CRT', { progression: 'eliminated' }),
     right: withParticipant('Ismail A.R', { progression: 'advanced' }),
   },
   {
     id: 4,
-    theme: 'Escher style impossible geometri',
+    theme: 'Refraction Labyrinth',
     left: withParticipant('Famii', { progression: 'eliminated' }),
     right: withParticipant('Aluh Gemoy', { progression: 'advanced' }),
   },
   {
     id: 5,
-    theme: 'Hyper-detailed Maximalism',
-    left: withParticipant('Mahidara', { progression: 'eliminated' }),
+    theme: 'Escher Style Impossible Geometry',
+    left: withParticipant('Dery Lau', { progression: 'eliminated' }),
     right: withParticipant('Winda A.', { progression: 'advanced' }),
   },
   {
     id: 6,
-    theme: 'Hypervoronoi Matrix',
+    theme: 'Hyperdetail Maximalist',
     left: withParticipant('David Amd', { progression: 'eliminated' }),
     right: withParticipant('Elena M.', { progression: 'advanced' }),
   },
   {
     id: 7,
     theme: 'Baroque Grotesque',
-    left: withParticipant('Dery Lau', { progression: 'eliminated' }),
+    left: withParticipant('Mahidara', { progression: 'eliminated' }),
     right: withParticipant('Rudi H.', { progression: 'advanced' }),
   },
   {


### PR DESCRIPTION
## Summary
- align the qualification bracket with the latest theme assignments for Aluh vs Famii, Bangteh vs Ismail, Dery vs Winda, David vs Elena, and Mahidara vs Rudi
- update David vs Elena to use the Hyperdetail Maximalist prompt per the revised brief

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb41df8530832eb18000c1a13e40ee