### PR TITLE
Add prompt submission access from prompt detail page

### DIFF
--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -4,7 +4,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { Prompt } from '../../lib/prompts';
 import Link from 'next/link';
-import PromptSubmissionForm from '../../components/PromptSubmissionForm';
+import PromptSubmissionTrigger from '../../components/PromptSubmissionTrigger';
 import Pagination from '../../components/Pagination';
 import AdBanner from '../../components/AdBanner';
 import { ArrowLeft } from 'lucide-react';
@@ -40,7 +40,6 @@ interface PromptClientProps {
 }
 
 export default function PromptClient({ prompts }: PromptClientProps) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
@@ -134,12 +133,7 @@ export default function PromptClient({ prompts }: PromptClientProps) {
       <div className="text-center mb-12">
         <h1 className="text-4xl md:text-5xl font-extrabold mb-4">Kumpulan Prompt</h1>
         <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">Jelajahi, gunakan, dan bagikan prompt kreatif untuk berbagai model AI.</p>
-        <button 
-          onClick={() => setIsModalOpen(true)}
-          className="mt-6 px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg"
-        >
-          Kirim Prompt Anda
-        </button>
+        <PromptSubmissionTrigger className="mt-6 px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg" />
       </div>
 
       <div className="mb-8 p-4 bg-gray-100 dark:bg-gray-800 rounded-lg">
@@ -239,10 +233,6 @@ export default function PromptClient({ prompts }: PromptClientProps) {
         />
       )}
 
-      <PromptSubmissionForm 
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-      />
     </div>
   );
 }

--- a/app/kumpulan-prompt/[slug]/page.tsx
+++ b/app/kumpulan-prompt/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import AdBanner from '@/components/AdBanner';
 import CopyButton from '@/components/CopyButton';
+import PromptSubmissionTrigger from '@/components/PromptSubmissionTrigger';
 
 export default async function PromptDetailPage({ params }: { params: { slug: string } }) {
   const prompts = await getAllPrompts();
@@ -78,8 +79,11 @@ export default async function PromptDetailPage({ params }: { params: { slug: str
         <p className="text-md text-gray-500 dark:text-gray-400 mb-2">Tanggal: {new Date(prompt.date).toLocaleDateString('id-ID')}</p>
         <p className="text-md text-gray-500 dark:text-gray-400 mb-6">Tool: {prompt.tool}</p>
 
-        <div className="mb-4 flex justify-end">
-          <CopyButton text={prompt.promptContent} />
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <PromptSubmissionTrigger className="w-full sm:w-auto px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg" />
+          <div className="flex w-full justify-end sm:w-auto">
+            <CopyButton text={prompt.promptContent} />
+          </div>
         </div>
         <div className="prose prose-lg max-w-none dark:prose-invert">
           <p>{prompt.promptContent}</p>

--- a/components/PromptSubmissionTrigger.tsx
+++ b/components/PromptSubmissionTrigger.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import PromptSubmissionForm from './PromptSubmissionForm';
+
+interface PromptSubmissionTriggerProps {
+  label?: ReactNode;
+  className?: string;
+}
+
+const DEFAULT_BUTTON_CLASS =
+  'px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg';
+
+export default function PromptSubmissionTrigger({
+  label = 'Kirim Prompt Anda',
+  className,
+}: PromptSubmissionTriggerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  return (
+    <>
+      <button type="button" onClick={handleOpen} className={className ?? DEFAULT_BUTTON_CLASS}>
+        {label}
+      </button>
+      <PromptSubmissionForm isOpen={isOpen} onClose={handleClose} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable client-side trigger component to open the prompt submission modal
- reuse the trigger on the prompt listing hero section instead of duplicating button logic
- show the submission button on the prompt detail page so users can share prompts without leaving the page

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc11cabbac832e95356f11c7da1b07