### PR TITLE
Fix dark mode article headings

### DIFF
--- a/app/artikel/[slug]/page.tsx
+++ b/app/artikel/[slug]/page.tsx
@@ -93,7 +93,9 @@ export default async function ArticlePage({ params }: { params: { slug: string }
         <ArrowLeft className="mr-2" size={20} />
         Kembali ke Artikel
       </Link>
-      <h1 className="text-4xl font-bold mb-4 text-center">{article.title}</h1>
+      <h1 className="text-4xl font-bold mb-4 text-center text-gray-900 dark:text-gray-100">
+        {article.title}
+      </h1>
       <p className="text-gray-600 dark:text-gray-400 text-center mb-2">
         Oleh {article.author} pada {new Date(article.date).toLocaleDateString('id-ID', { year: 'numeric', month: 'long', day: 'numeric' })}
       </p>
@@ -133,7 +135,9 @@ export default async function ArticlePage({ params }: { params: { slug: string }
 
       {relatedArticles.length > 0 && (
         <div className="mt-12">
-          <h2 className="text-3xl font-bold mb-6 text-center">Artikel Terkait</h2>
+          <h2 className="text-3xl font-bold mb-6 text-center text-gray-900 dark:text-gray-100">
+            Artikel Terkait
+          </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {relatedArticles.map(relatedArticle => (
               <Link key={relatedArticle.slug} href={`/artikel/${relatedArticle.slug}`} className="block p-6 bg-white dark:bg-gray-800 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300">

--- a/app/artikel/page.tsx
+++ b/app/artikel/page.tsx
@@ -19,7 +19,7 @@ export default function ArticleListPage() {
           <span>Kembali ke Beranda</span>
         </Link>
       </div>
-      <h1 className="text-4xl font-bold mb-8 text-center">Artikel</h1>
+      <h1 className="text-4xl font-bold mb-8 text-center text-gray-900 dark:text-gray-100">Artikel</h1>
       <ArticlePaginationClient initialArticles={articles} adSlotId={adSlotId} />
     </div>
   );


### PR DESCRIPTION
## Summary
- ensure the article page title uses light text when rendered in dark mode
- adjust the related articles heading to remain readable on dark backgrounds

## Testing
- pnpm lint *(warnings about existing <img> usage and hook dependencies remain)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2f53bb40832e8f86962ed6ed2d71