### PR TITLE
Set default AdSense slot for article list page

### DIFF
--- a/app/artikel/page.tsx
+++ b/app/artikel/page.tsx
@@ -4,9 +4,12 @@ import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import ArticlePaginationClient from './ArticlePaginationClient';
 
+const DEFAULT_AD_SLOT_ID = '7992484013';
+
 export default function ArticleListPage() {
   const articles = getAllArticles();
-  const adSlotId = process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_ID_3 || '';
+  const adSlotId =
+    process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_ID_3 || DEFAULT_AD_SLOT_ID;
 
   return (
     <div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary
- define a default AdSense slot ID constant for the article list page
- fall back to the default slot when the environment variable is not defined so the banner always receives a value

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb762dcd0832ebb58b0530bdafae7