### PR TITLE
Improve AdSense slots on article and prompt pages

### DIFF
--- a/app/artikel/[slug]/page.tsx
+++ b/app/artikel/[slug]/page.tsx
@@ -10,6 +10,7 @@ import type { Parent } from 'unist';
 import { visit } from 'unist-util-visit';
 import type { Plugin } from 'unified';
 import AdBanner from '@/components/AdBanner';
+import { ARTICLE_BOTTOM_AD_SLOT, ARTICLE_INLINE_AD_SLOT } from '@/lib/adsense';
 
 interface ParagraphData extends Record<string, unknown> {
   shouldInsertAdAfter?: boolean;
@@ -102,7 +103,8 @@ export default async function ArticlePage({ params }: { params: { slug: string }
   // Variabel relatedArticles didefinisikan di dalam komponen
   const relatedArticles = getRelatedArticles(params.slug);
 
-  const articleAdSlot = '7992484013';
+  const inlineAdSlot = ARTICLE_INLINE_AD_SLOT;
+  const bottomAdSlot = ARTICLE_BOTTOM_AD_SLOT;
 
   const markdownComponents: Components = {
     p({ node, children, ...props }) {
@@ -118,9 +120,12 @@ export default async function ArticlePage({ params }: { params: { slug: string }
       return (
         <>
           <p {...paragraphProps}>{children}</p>
-          {adFlagValue && (
+          {adFlagValue && inlineAdSlot && (
             <div className="my-8">
-              <AdBanner dataAdSlot={articleAdSlot} />
+              <AdBanner
+                key={`article-inline-ad-${article.slug}`}
+                dataAdSlot={inlineAdSlot}
+              />
             </div>
           )}
         </>
@@ -221,9 +226,14 @@ export default async function ArticlePage({ params }: { params: { slug: string }
         </div>
       )}
 
-      <div className="my-8">
-        <AdBanner dataAdSlot={articleAdSlot} />
-      </div>
+      {bottomAdSlot && (
+        <div className="my-8">
+          <AdBanner
+            key={`article-bottom-ad-${article.slug}`}
+            dataAdSlot={bottomAdSlot}
+          />
+        </div>
+      )}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/app/artikel/page.tsx
+++ b/app/artikel/page.tsx
@@ -1,15 +1,15 @@
 
 import { getAllArticles } from '@/lib/articles';
+import { ARTICLE_BOTTOM_AD_SLOT, ARTICLE_LIST_AD_SLOT } from '@/lib/adsense';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import ArticlePaginationClient from './ArticlePaginationClient';
 
-const DEFAULT_AD_SLOT_ID = '7992484013';
-
 export default function ArticleListPage() {
   const articles = getAllArticles();
-  const adSlotId =
-    process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_ID_3 || DEFAULT_AD_SLOT_ID;
+  const adSlotIds = [ARTICLE_LIST_AD_SLOT, ARTICLE_BOTTOM_AD_SLOT].filter(
+    (slot): slot is string => Boolean(slot),
+  );
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -23,7 +23,7 @@ export default function ArticleListPage() {
         </Link>
       </div>
       <h1 className="text-4xl font-bold mb-8 text-center text-gray-900 dark:text-gray-100">Artikel</h1>
-      <ArticlePaginationClient initialArticles={articles} adSlotId={adSlotId} />
+      <ArticlePaginationClient initialArticles={articles} adSlotIds={adSlotIds} />
     </div>
   );
 }

--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import PromptSubmissionTrigger from '../../components/PromptSubmissionTrigger';
 import Pagination from '../../components/Pagination';
 import AdBanner from '../../components/AdBanner';
+import { PROMPT_BOTTOM_AD_SLOT, PROMPT_TOP_AD_SLOT } from '../../lib/adsense';
 import { ArrowLeft } from 'lucide-react';
 import { usePromptSuggestions } from './usePromptSuggestions';
 
@@ -45,6 +46,8 @@ export default function PromptClient({ prompts }: PromptClientProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const topAdSlot = PROMPT_TOP_AD_SLOT;
+  const bottomAdSlot = PROMPT_BOTTOM_AD_SLOT;
 
   const allTags = useMemo(() => {
     const tags = new Set<string>();
@@ -185,6 +188,12 @@ export default function PromptClient({ prompts }: PromptClientProps) {
         </div>
       </div>
 
+      {topAdSlot && (
+        <div className="my-8">
+          <AdBanner key="prompt-top-ad" dataAdSlot={topAdSlot} />
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {paginatedPrompts.map((prompt: Prompt) => (
           <Link key={prompt.id} href={`/kumpulan-prompt/${prompt.slug}`}>
@@ -221,9 +230,14 @@ export default function PromptClient({ prompts }: PromptClientProps) {
         ))}
       </div>
 
-      <div className="my-8">
-        <AdBanner dataAdSlot="5961316189" />
-      </div>
+      {bottomAdSlot && (
+        <div className="my-8">
+          <AdBanner
+            key={`prompt-bottom-ad-${currentPage}`}
+            dataAdSlot={bottomAdSlot}
+          />
+        </div>
+      )}
 
       {totalPages > 1 && (
         <Pagination 

--- a/lib/adsense.ts
+++ b/lib/adsense.ts
@@ -3,3 +3,53 @@ export const DEFAULT_ADSENSE_PUBLISHER_ID = 'ca-pub-1439044724518446';
 export const ADSENSE_PUBLISHER_ID =
   process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID ?? DEFAULT_ADSENSE_PUBLISHER_ID;
 
+const sanitizeAdUnit = (value?: string | null) => value?.trim() ?? '';
+
+const resolveAdSlotId = (
+  ...candidates: Array<string | undefined | null>
+): string => {
+  for (const candidate of candidates) {
+    const sanitized = sanitizeAdUnit(candidate);
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+
+  return '';
+};
+
+const DEFAULT_PRIMARY_AD_SLOT = '6897039624';
+const DEFAULT_SECONDARY_AD_SLOT = '5961316189';
+const DEFAULT_TERTIARY_AD_SLOT = '7992484013';
+
+export const ARTICLE_LIST_AD_SLOT = resolveAdSlotId(
+  process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_ARTICLE_LIST,
+  process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_ID_3,
+  DEFAULT_PRIMARY_AD_SLOT,
+);
+
+export const ARTICLE_INLINE_AD_SLOT = resolveAdSlotId(
+  process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_ARTICLE_INLINE,
+  ARTICLE_LIST_AD_SLOT,
+  DEFAULT_TERTIARY_AD_SLOT,
+  DEFAULT_PRIMARY_AD_SLOT,
+);
+
+export const ARTICLE_BOTTOM_AD_SLOT = resolveAdSlotId(
+  process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_ARTICLE_BOTTOM,
+  DEFAULT_SECONDARY_AD_SLOT,
+  DEFAULT_PRIMARY_AD_SLOT,
+);
+
+export const PROMPT_TOP_AD_SLOT = resolveAdSlotId(
+  process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_PROMPT_TOP,
+  ARTICLE_LIST_AD_SLOT,
+  DEFAULT_PRIMARY_AD_SLOT,
+);
+
+export const PROMPT_BOTTOM_AD_SLOT = resolveAdSlotId(
+  process.env.NEXT_PUBLIC_ADSENSE_AD_SLOT_PROMPT_BOTTOM,
+  DEFAULT_SECONDARY_AD_SLOT,
+  DEFAULT_PRIMARY_AD_SLOT,
+);
+


### PR DESCRIPTION
## Summary
- centralize AdSense slot resolution with defaults to working units
- rotate interstitial ads on the article list and reuse reliable slots on article detail
- surface top and bottom ad slots on the prompt collection page for better fill

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68cef1125358832eb082b6d2e27d82f0