### PR TITLE
Fix prompt dates and Gemini tool name

### DIFF
--- a/content/prompts/prompt-110.md
+++ b/content/prompts/prompt-110.md
@@ -1,0 +1,20 @@
+---
+id: "110"
+slug: "clayface-emerald-swamp-terror"
+title: "Clayface"
+author: "Ayu Dian"
+date: "2025-09-22"
+tool: "Gemini"
+tags:
+  - horror
+  - mud
+  - green
+  - roots
+  - creepy
+---
+
+Summon an ultra-detailed 9:16 cinematic horror tableau of Ayu Dian transformed into a monstrous clay-like entity emerging from a dark swampy forest. Her entire body is sculpted from mud and soil, distorted and asymmetrical, with grotesque limbs constantly reshaping and dripping as if the earth itself is alive. Weave emerald and gold glowing veins through the clay mass, illuminating long straight silver hair matted with muck and partially submerged in sludge.
+
+Embed multiple tortured human faces within the clay surface, their expressions frozen mid-scream, half-buried and twisting as if trapped souls are trying to claw free. Let her form merge seamlessly with the swamp pit, tree roots, and moss-covered earth—warped trunks and tangled roots should dissolve into her body, making it impossible to tell where the creature ends and the environment begins.
+
+Flood the scene with thick emerald mist and warped shadowed trees, keeping the lighting cinematic yet oppressive: deep darkness pierced by the eerie green luminescence and sharp golden highlights licking across wet textures. Focus on hyper-realistic mud and clay surfaces, dripping strands, and constantly shifting anatomy. Emphasize a predatory awakening mood, chaotic and nightmarish, while avoiding anything cartoonish or 3D-rendered—this should feel like a living horror fantasy captured in photoreal detail.

--- a/content/prompts/prompt-111.md
+++ b/content/prompts/prompt-111.md
@@ -1,0 +1,14 @@
+---
+id: "111"
+slug: "horor-senja-berkabut"
+title: "Horor"
+author: "Mohamad Gozali"
+date: "2025-09-22"
+tool: "Dall-E"
+tags:
+  - horor
+---
+
+Visualisasikan suasana horor menjelang malam di tepi hutan berkabut. Bentangkan lanskap alami yang redup antara senja dan malam, dengan langit jingga gelap yang memudar ke biru keunguan serta kabut tebal merambat rendah di atas tanah. Gunakan pencahayaan remang dengan sorotan cahaya dingin yang menembus celah pepohonan rimbun, menghasilkan siluet tajam sekaligus bayangan panjang yang menyeramkan.
+
+Tambah elemen detail seperti pepohonan tinggi yang tampak bengkok, dedaunan basah yang memantulkan sedikit kilau, dan jalan tanah berlumpur yang seolah memandu pandangan menuju kegelapan dalam hutan. Sisipkan titik-titik cahaya kecil yang ambigu—apakah lampu jauh atau mata makhluk—untuk memperkuat ketegangan. Pastikan atmosfernya terasa sunyi, dingin, dan menegangkan, seolah sesuatu mengintai di balik tirai kabut.

--- a/content/prompts/prompt-112.md
+++ b/content/prompts/prompt-112.md
@@ -1,0 +1,20 @@
+---
+id: "112"
+slug: "poster-romantis-vespa-punk"
+title: "Poster film romantis"
+author: "Rete"
+date: "2025-09-22"
+tool: "Gemini"
+tags:
+  - poster
+  - romantic
+  - street-punk
+  - vespa
+  - pastel
+---
+
+Rancang poster film drama romansa bertema street punk rebel dalam gaya grafis berlapis yang tajam. Gunakan latar belakang oranye pastel penuh energi dengan coretan doodle putih, kuning, dan pink bertema vespa, ikon kota dunia, serta ornamen bernuansa islami yang saling bertumpuk. Terapkan efek double exposure agar doodle berantakan menyatu dengan seluruh komposisi.
+
+Di tengah komposisi, hadirkan sobekan kertas ungu berbentuk lingkaran konsentris sebagai ruang teks utama. Tulis judul "RuangRiung" dengan font huruf sambung yang elegan namun berjiwa bebas, seolah tercetak pada kertas kolase. Pastikan tepi sobekan terlihat bertekstur dan memiliki bayangan halus untuk memberi kesan tiga dimensi.
+
+Letakkan pemeran utama di depan, berdiri di atas vespa putih klasik. Sang gadis berambut panjang memakai scarf dan menampilkan ekspresi ceria, sementara pria tampan di sampingnya mengenakan topi fedora merah, kaos hitam bertulisan "rete", celana jeans sobek, dan sepatu Converse merah sambil tersenyum percaya diri. Komposisi harus terasa romantis sekaligus berani, memadukan nuansa rebel street art dengan kelembutan pastel modern.


### PR DESCRIPTION
## Summary
- update the Clayface, Horor, and romantic poster prompts to use the 2025-09-22 publication date
- correct the Rete prompt tool field from Geminj to Gemini

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d058871648832ebf5fe8e6e60a96f9