### PR TITLE
Add content creator CTA button on home page

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,6 +1,22 @@
 'use client'; // Tandai sebagai Client Component
 
-import { Wand2, Sparkles, Download, X, Rss, Facebook, Mail, LayoutGrid, EarthIcon, BookOpen, QrCode, ChevronDown, MessageSquare } from 'lucide-react';
+import {
+  Wand2,
+  Sparkles,
+  Download,
+  X,
+  Rss,
+  Facebook,
+  Mail,
+  LayoutGrid,
+  EarthIcon,
+  BookOpen,
+  QrCode,
+  ChevronDown,
+  MessageSquare,
+  Megaphone,
+  ArrowRight,
+} from 'lucide-react';
 import Tabs from '../components/Tabs';
 import AuthButton from '@/components/AuthButton';
 import ThemeToggle from '@/components/ThemeToggle';
@@ -138,7 +154,28 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
           <span>Email Kami</span>
         </Link>
       </div>
-      
+
+      <div className="w-full max-w-4xl mb-6">
+        <Link
+          href="/konten-kreator"
+          className="group w-full inline-flex items-center justify-between gap-4 px-6 py-5 rounded-2xl bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 text-white font-bold shadow-xl transition-all duration-200 hover:scale-[1.02] hover:shadow-2xl focus:outline-none focus:ring-2 focus:ring-purple-300 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900"
+        >
+          <div className="flex items-center gap-4">
+            <span className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/20">
+              <Megaphone className="h-6 w-6 animate-pulse transition-transform group-hover:scale-110" />
+              <span className="absolute -right-1 -top-1 h-3 w-3 animate-ping rounded-full bg-yellow-300" aria-hidden />
+            </span>
+            <div className="text-left">
+              <p className="text-lg sm:text-xl leading-tight">Build Your Brand Here</p>
+              <p className="text-sm sm:text-base font-normal text-white/80">
+                Masuk ke etalase konten kreator kami dan dapatkan eksposur lebih untuk karya terbaikmu.
+              </p>
+            </div>
+          </div>
+          <ArrowRight className="h-6 w-6 transition-transform duration-200 group-hover:translate-x-1" />
+        </Link>
+      </div>
+
       <div className="w-full max-w-4xl mb-4">
         <PromptSubmissionTrigger
           className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 bg-blue-600 text-white font-bold rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset hover:bg-blue-700 transition-colors"

--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -139,7 +139,7 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
           className="flex items-center justify-center text-center gap-2 px-4 py-3 bg-light-bg dark:bg-dark-bg text-gray-700 dark:text-gray-300 font-semibold text-sm rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all"
         >
           <LayoutGrid size={18} />
-          <span>Kumpulan Prompt AI</span>
+          <span>Prompt AI</span>
         </Link>
         <Link href="/artikel" className="flex items-center justify-center text-center gap-2 px-4 py-3 bg-light-bg dark:bg-dark-bg text-gray-700 dark:text-gray-300 font-semibold text-sm rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all">
           <Rss size={18} />


### PR DESCRIPTION
## Summary
- add a gradient call-to-action button on the home page linking to the content creator showcase
- include interactive megaphone and arrow icons to draw attention to the new CTA

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0987a00c0832e9f54fe0fc4117a1f