### PR TITLE
Remove prompt editing from prompt pages

### DIFF
--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -97,28 +97,17 @@ export default function PromptClient({ prompts }: PromptClientProps) {
     }
   }, []);
 
-  const upsertPrompt = useCallback((nextPrompt: Prompt) => {
-    setPromptList(previous => {
-      const filtered = previous.filter(prompt => prompt.slug !== nextPrompt.slug);
-      return sortPrompts([nextPrompt, ...filtered]);
-    });
-  }, []);
-
   const handlePromptCreated = useCallback(
     (nextPrompt: Prompt) => {
-      upsertPrompt(nextPrompt);
+      setPromptList(previous => {
+        const filtered = previous.filter(prompt => prompt.slug !== nextPrompt.slug);
+        return sortPrompts([nextPrompt, ...filtered]);
+      });
       setCurrentPage(1);
       hasInteractedWithPaginationRef.current = true;
       scrollToPromptListTop();
     },
-    [scrollToPromptListTop, upsertPrompt],
-  );
-
-  const handlePromptUpdated = useCallback(
-    (nextPrompt: Prompt) => {
-      upsertPrompt(nextPrompt);
-    },
-    [upsertPrompt],
+    [scrollToPromptListTop],
   );
 
   const filteredPrompts = useMemo(() => {
@@ -299,15 +288,6 @@ export default function PromptClient({ prompts }: PromptClientProps) {
                 ))}
               </div>
             </Link>
-            <div className="mt-4 flex justify-end">
-              <PromptSubmissionTrigger
-                mode="edit"
-                prompt={prompt}
-                onSuccess={handlePromptUpdated}
-                label="Edit Prompt"
-                className="rounded-md border border-blue-500 px-4 py-2 text-sm font-semibold text-blue-600 transition hover:bg-blue-50 dark:border-blue-400 dark:text-blue-200 dark:hover:bg-blue-900/30"
-              />
-            </div>
           </div>
         ))}
       </div>

--- a/app/kumpulan-prompt/[slug]/PromptDetailClient.tsx
+++ b/app/kumpulan-prompt/[slug]/PromptDetailClient.tsx
@@ -19,7 +19,7 @@ interface PromptDetailClientProps {
 }
 
 export default function PromptDetailClient({ prompt, prompts }: PromptDetailClientProps) {
-  const [currentPrompt, setCurrentPrompt] = useState(prompt);
+  const currentPrompt = prompt;
   const [promptCollection, setPromptCollection] = useState(() => sortPrompts(prompts));
 
   const relatedPrompts = useMemo(() => {
@@ -37,14 +37,6 @@ export default function PromptDetailClient({ prompt, prompts }: PromptDetailClie
       })
       .slice(0, 4);
   }, [promptCollection, currentPrompt]);
-
-  const handlePromptUpdated = (updatedPrompt: Prompt) => {
-    setCurrentPrompt(updatedPrompt);
-    setPromptCollection(previous => {
-      const filtered = previous.filter(item => item.slug !== updatedPrompt.slug);
-      return sortPrompts([updatedPrompt, ...filtered]);
-    });
-  };
 
   const handlePromptCreated = (createdPrompt: Prompt) => {
     setPromptCollection(previous => {
@@ -111,13 +103,6 @@ export default function PromptDetailClient({ prompt, prompts }: PromptDetailClie
             <PromptSubmissionTrigger
               className="w-full sm:w-auto px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg"
               onSuccess={handlePromptCreated}
-            />
-            <PromptSubmissionTrigger
-              mode="edit"
-              prompt={currentPrompt}
-              onSuccess={handlePromptUpdated}
-              label="Edit Prompt Ini"
-              className="w-full sm:w-auto px-8 py-3 rounded-full border border-blue-500 font-semibold text-blue-600 transition hover:bg-blue-50 dark:border-blue-400 dark:text-blue-200 dark:hover:bg-blue-900/30"
             />
           </div>
           <div className="flex w-full justify-end sm:w-auto">


### PR DESCRIPTION
## Summary
- remove edit prompt trigger from the prompt collection grid
- simplify the prompt detail page to drop the edit trigger while keeping prompt submissions functional

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d20bcdbad0832eac9de21a9ec7cc3d