### PR TITLE
Add keyword help modal to UniqueArtName

### DIFF
--- a/app/UniqueArtName/KeywordGeneratorClient.tsx
+++ b/app/UniqueArtName/KeywordGeneratorClient.tsx
@@ -1523,42 +1523,43 @@ const KeywordGeneratorClient = () => {
     </div>
 
       {isKeywordHelpOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+        <div className="fixed inset-0 z-50">
           <div
             className="absolute inset-0 bg-gray-900/70"
             onClick={() => setIsKeywordHelpOpen(false)}
             aria-hidden="true"
           />
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby={keywordHelpTitleId}
-            className="relative z-10 w-full max-w-3xl rounded-3xl bg-white/95 p-6 text-gray-800 shadow-neumorphic backdrop-blur-sm dark:bg-dark-neumorphic-light/95 dark:text-gray-100 dark:shadow-dark-neumorphic"
-          >
-            <button
-              type="button"
-              onClick={() => setIsKeywordHelpOpen(false)}
-              className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-purple-100 text-purple-700 transition hover:bg-purple-200 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:bg-purple-500/10 dark:text-purple-100 dark:hover:bg-purple-500/20"
+          <div className="relative z-10 flex min-h-full items-start justify-center overflow-y-auto px-4 py-6 sm:items-center">
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={keywordHelpTitleId}
+              className="relative w-full max-w-3xl max-h-[calc(100vh-3rem)] overflow-y-auto rounded-3xl bg-white/95 p-6 text-gray-800 shadow-neumorphic backdrop-blur-sm dark:bg-dark-neumorphic-light/95 dark:text-gray-100 dark:shadow-dark-neumorphic sm:max-h-[calc(100vh-4rem)]"
             >
-              <span className="sr-only">Tutup panduan kata kunci</span>
-              <X className="h-5 w-5" />
-            </button>
-            <div className="space-y-5 pt-2">
-              <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() => setIsKeywordHelpOpen(false)}
+                className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-purple-100 text-purple-700 transition hover:bg-purple-200 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:bg-purple-500/10 dark:text-purple-100 dark:hover:bg-purple-500/20"
+              >
+                <span className="sr-only">Tutup panduan kata kunci</span>
+                <X className="h-5 w-5" />
+              </button>
+              <div className="space-y-5 pt-2">
+                <div className="space-y-2">
                 <p className="inline-flex items-center gap-2 rounded-full bg-purple-100/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-purple-700 dark:bg-purple-500/10 dark:text-purple-200">
                   <Sparkles className="h-4 w-4" />
                   Panduan Cepat
-                </p>
-                <h3 id={keywordHelpTitleId} className="text-2xl font-bold text-purple-700 dark:text-purple-200">
+                  </p>
+                  <h3 id={keywordHelpTitleId} className="text-2xl font-bold text-purple-700 dark:text-purple-200">
                   Eksperimen Kata Kunci Lebih Efektif
-                </h3>
-                <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                  </h3>
+                  <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
                   Ikuti langkah ringkas berikut agar setiap daftar kata kunci terasa segar, relevan dengan visi visualmu, dan mudah dipadukan menjadi prompt.
-                </p>
+                  </p>
               </div>
 
-              <ol className="space-y-3 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-                <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
+                <ol className="space-y-3 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                  <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
                   <span className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-purple-200 text-sm font-semibold text-purple-800 dark:bg-purple-500/30 dark:text-purple-100">
                     1
                   </span>
@@ -1568,8 +1569,8 @@ const KeywordGeneratorClient = () => {
                       Tulis gambaran utamamu pada kolom <strong>Tema Utama</strong>. Satu atau dua kalimat sudah cukup untuk mengarahkan model menuju suasana yang kamu bayangkan.
                     </p>
                   </div>
-                </li>
-                <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
+                  </li>
+                  <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
                   <span className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-purple-200 text-sm font-semibold text-purple-800 dark:bg-purple-500/30 dark:text-purple-100">
                     2
                   </span>
@@ -1579,8 +1580,8 @@ const KeywordGeneratorClient = () => {
                       Gunakan kolom <strong>Arah Gaya / Hal Khusus</strong> untuk menyebut detail spesifik: teknik, warna, gabungan bahasa, atau elemen budaya. Detail ini membantu AI membuat istilah yang lebih tajam.
                     </p>
                   </div>
-                </li>
-                <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
+                  </li>
+                  <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
                   <span className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-purple-200 text-sm font-semibold text-purple-800 dark:bg-purple-500/30 dark:text-purple-100">
                     3
                   </span>
@@ -1590,8 +1591,8 @@ const KeywordGeneratorClient = () => {
                       Setelah menekan <strong>Generate Tema Unik</strong>, baca tiap deskripsi. Gabungkan istilah yang saling melengkapi lalu tekan <strong>Salin Semua</strong> untuk menyimpannya sebagai referensi prompt.
                     </p>
                   </div>
-                </li>
-                <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
+                  </li>
+                  <li className="flex gap-3 rounded-2xl bg-purple-50/70 p-4 dark:bg-purple-500/10">
                   <span className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-purple-200 text-sm font-semibold text-purple-800 dark:bg-purple-500/30 dark:text-purple-100">
                     4
                   </span>
@@ -1601,26 +1602,27 @@ const KeywordGeneratorClient = () => {
                       Aktifkan daftar seniman untuk menambah referensi visual, atau gunakan <strong>Panel Pertanyaan Kilat</strong> guna meminta variasi baru tanpa kehilangan konteks hasil sebelumnya.
                     </p>
                   </div>
-                </li>
-              </ol>
+                  </li>
+                </ol>
 
-              <div className="space-y-2 rounded-2xl bg-white/80 p-4 text-sm text-gray-700 shadow-inner dark:bg-dark-neumorphic-light/80 dark:text-gray-200">
-                <p className="font-semibold text-gray-900 dark:text-gray-100">Tips tambahan:</p>
-                <ul className="list-disc space-y-1 pl-5">
+                <div className="space-y-2 rounded-2xl bg-white/80 p-4 text-sm text-gray-700 shadow-inner dark:bg-dark-neumorphic-light/80 dark:text-gray-200">
+                  <p className="font-semibold text-gray-900 dark:text-gray-100">Tips tambahan:</p>
+                  <ul className="list-disc space-y-1 pl-5">
                   <li>Coba kombinasikan dua atau tiga kata kunci unik menjadi satu frasa prompt untuk efek yang lebih dramatis.</li>
                   <li>Simpan batch kata kunci favoritmu sebelum mengklik <strong>Reset</strong> agar ide langka tidak hilang.</li>
                   <li>Gunakan mode gelap/terang sesuai kebutuhan agar sesi eksplorasi panjang tetap nyaman.</li>
-                </ul>
-              </div>
+                  </ul>
+                </div>
 
-              <div className="flex justify-end">
-                <button
+                <div className="flex justify-end">
+                  <button
                   type="button"
                   onClick={() => setIsKeywordHelpOpen(false)}
                   className="inline-flex items-center gap-2 rounded-2xl bg-purple-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-                >
+                  >
                   Mengerti
-                </button>
+                  </button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a help icon beside the Unique Art Name keyword generator heading that opens a tutorial modal
- implement a modal overlay with actionable steps and tips for composing keywords, including escape and backdrop dismissal support

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2804acbb8832eb021aa8a79e35f05