### PR TITLE
Handle prompt submission on read-only deployments

### DIFF
--- a/components/PromptSubmissionForm.tsx
+++ b/components/PromptSubmissionForm.tsx
@@ -144,6 +144,8 @@ export default function PromptSubmissionForm({
       }
 
       const prompt: Prompt | undefined = data?.prompt;
+      const persisted: boolean =
+        typeof data?.persisted === 'boolean' ? data.persisted : true;
 
       if (!prompt) {
         throw new Error('Server tidak mengembalikan data prompt.');
@@ -173,11 +175,12 @@ export default function PromptSubmissionForm({
       }
 
       setSubmitStatus('success');
-      setFeedbackMessage(
-        isEditMode
-          ? 'Prompt berhasil diperbarui dan perubahan langsung ditayangkan.'
-          : 'Prompt berhasil dikirim dan langsung dipublikasikan.',
-      );
+      const successMessage = isEditMode
+        ? 'Prompt berhasil diperbarui dan perubahan langsung ditayangkan.'
+        : persisted
+            ? 'Prompt berhasil dikirim dan langsung dipublikasikan.'
+            : 'Prompt berhasil dikirim. Tim kami akan meninjau dan memublikasikannya secara manual.';
+      setFeedbackMessage(successMessage);
 
       onSuccess?.(prompt);
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- allow prompt submissions to succeed when the filesystem is read-only by returning an in-memory prompt when persistence fails
- include the storage status in the submission email and API response so the UI and admins know when manual action is needed
- surface a user-friendly success message when a prompt cannot be stored automatically

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4078aa518832e93e048a7ddc7c2f3