### PR TITLE
Adjust fallback prompt slug formatting

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -204,7 +204,7 @@ export async function createPrompt(payload: PromptPayload): Promise<PromptCreati
       const fallbackPrompt: Prompt = {
         ...prompt,
         id: `${prompt.id}-${Date.now()}`,
-        slug: `${prompt.slug}-${Date.now()}`,
+        slug: prompt.slug,
       };
 
       return { prompt: fallbackPrompt, persisted: false } satisfies PromptCreationResult;


### PR DESCRIPTION
## Summary
- keep the fallback prompt slug unchanged when persistence fails so it remains human-friendly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d40c07b6bc832e8276a4a9cbc88e26