### PR TITLE
feat(umkm): add dark mode toggle and improve pagination UX

### DIFF
--- a/app/umkm/[storeId]/page.tsx
+++ b/app/umkm/[storeId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 
 import { StoreShowcase } from '../_components/StoreShowcase';
 import { getStoreById, getStores } from '@/lib/umkm';
+import ThemeToggle from '@/components/ThemeToggle';
 
 interface PageProps {
   params: {
@@ -78,12 +79,12 @@ export default async function StoreDetailPage({ params }: PageProps) {
   }
 
   return (
-    <div className="bg-white pb-20 pt-12 text-slate-900">
+    <div className="bg-white pb-20 pt-12 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
           <Link
             href="/umkm"
-            className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 transition hover:text-indigo-800"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 transition hover:text-indigo-800 dark:text-indigo-300 dark:hover:text-indigo-200"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -101,7 +102,7 @@ export default async function StoreDetailPage({ params }: PageProps) {
 
           <Link
             href="/"
-            className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100"
+            className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800/60"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -116,6 +117,10 @@ export default async function StoreDetailPage({ params }: PageProps) {
             </svg>
             Kembali ke Beranda
           </Link>
+
+          <div className="w-full sm:w-auto sm:min-w-[220px]">
+            <ThemeToggle />
+          </div>
         </div>
 
         <StoreShowcase store={store} />

--- a/app/umkm/_components/StoreShowcase.tsx
+++ b/app/umkm/_components/StoreShowcase.tsx
@@ -69,14 +69,14 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
 
         <section className="mt-8 space-y-4">
           <header className="space-y-2">
-            <span className="inline-flex items-center gap-2 rounded-full bg-indigo-100 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+            <span className="inline-flex items-center gap-2 rounded-full bg-indigo-100 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
               {store.category}
             </span>
-            <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">{store.name}</h1>
-            <p className="text-base text-slate-600 sm:text-lg">{store.location}</p>
+            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-50 sm:text-4xl">{store.name}</h1>
+            <p className="text-base text-slate-600 dark:text-slate-300 sm:text-lg">{store.location}</p>
           </header>
 
-          <p className="break-words text-base leading-relaxed text-slate-700 sm:text-lg">
+          <p className="break-words text-base leading-relaxed text-slate-700 dark:text-slate-200 sm:text-lg">
             {store.description}
           </p>
 
@@ -84,7 +84,7 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
             {store.highlights.map((highlight) => (
               <li
                 key={highlight}
-                className="flex items-start gap-3 rounded-2xl bg-white px-4 py-3 text-sm font-medium text-slate-700 shadow sm:text-base"
+                className="flex items-start gap-3 rounded-2xl bg-white px-4 py-3 text-sm font-medium text-slate-700 shadow sm:text-base dark:bg-slate-900 dark:text-slate-200"
               >
                 <span className="mt-0.5 inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-500 text-xs font-bold text-white">
                   ✔
@@ -96,17 +96,17 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
         </section>
       </div>
 
-      <aside className="flex flex-col gap-8 rounded-3xl border border-slate-200 bg-slate-50/60 p-6 shadow-inner">
+      <aside className="flex flex-col gap-8 rounded-3xl border border-slate-200 bg-slate-50/60 p-6 shadow-inner dark:border-slate-700 dark:bg-slate-900/60">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Hubungi {store.name}</h2>
-          <p className="mt-1 break-words text-sm text-slate-600 sm:text-base">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">Hubungi {store.name}</h2>
+          <p className="mt-1 break-words text-sm text-slate-600 dark:text-slate-300 sm:text-base">
             Siap membantu kebutuhan Anda melalui WhatsApp dengan balasan cepat.
           </p>
           <a
             href={`${whatsappBase}?text=${encodeURIComponent(`Halo ${store.name}! Saya tertarik dengan produk-produk Anda.`)}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center justify-center gap-2 rounded-xl bg-green-500 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            className="mt-4 inline-flex items-center justify-center gap-2 rounded-xl bg-green-500 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-950"
           >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true" className="h-5 w-5">
               <path
@@ -119,8 +119,8 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Produk Unggulan</h2>
-          <p className="mt-1 break-words text-sm text-slate-600 sm:text-base">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">Produk Unggulan</h2>
+          <p className="mt-1 break-words text-sm text-slate-600 dark:text-slate-300 sm:text-base">
             Klik foto produk untuk melihat tampilan penuh serta detail lengkapnya.
           </p>
 
@@ -133,12 +133,12 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
               return (
                 <article
                   key={product.name}
-                  className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+                  className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900"
                 >
                   <button
                     type="button"
                     onClick={() => setActiveProduct(product)}
-                    className="group relative block h-40 w-full overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                    className="group relative block h-40 w-full overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-950"
                   >
                     <Image
                       src={product.image}
@@ -151,10 +151,10 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
                   </button>
                   <div className="flex flex-1 flex-col gap-3 px-4 py-3 text-left">
                     <div className="flex flex-col gap-1">
-                      <h3 className="text-base font-semibold text-slate-900 sm:text-lg">{product.name}</h3>
-                      <span className="text-sm font-medium text-indigo-600 sm:text-base">{product.price}</span>
+                      <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100 sm:text-lg">{product.name}</h3>
+                      <span className="text-sm font-medium text-indigo-600 dark:text-indigo-300 sm:text-base">{product.price}</span>
                     </div>
-                    <p className="break-words text-sm leading-relaxed text-slate-600 sm:text-base">
+                    <p className="break-words text-sm leading-relaxed text-slate-600 dark:text-slate-300 sm:text-base">
                       {product.description}
                     </p>
                     <div className="mt-auto flex flex-wrap gap-2">
@@ -163,7 +163,7 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label={`Hubungi ${store.name} untuk ${product.name} via WhatsApp`}
-                        className="inline-flex items-center justify-center gap-2 rounded-xl bg-green-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                        className="inline-flex items-center justify-center gap-2 rounded-xl bg-green-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-950"
                       >
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
@@ -180,7 +180,7 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
                       </a>
                       <Link
                         href={`/umkm`}
-                        className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                        className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800/60 dark:focus-visible:ring-offset-slate-950"
                       >
                         Lihat Toko Lain
                       </Link>
@@ -212,13 +212,13 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
           onClick={() => setActiveProduct(null)}
         >
           <div
-            className="relative flex w-full max-w-3xl flex-col overflow-hidden rounded-3xl bg-white shadow-2xl shadow-slate-900/20 max-h-[90vh] sm:max-h-[85vh]"
+            className="relative flex w-full max-w-3xl flex-col overflow-hidden rounded-3xl bg-white shadow-2xl shadow-slate-900/20 max-h-[90vh] sm:max-h-[85vh] dark:bg-slate-950"
             onClick={(event) => event.stopPropagation()}
           >
             <button
               type="button"
               onClick={() => setActiveProduct(null)}
-              className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-slate-700 shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-slate-700 shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:bg-slate-900/90 dark:text-slate-200"
             >
               <span className="sr-only">Tutup pratinjau</span>
               ×
@@ -234,9 +234,9 @@ export function StoreShowcase({ store }: StoreShowcaseProps) {
               />
             </div>
             <div className="flex-1 space-y-3 overflow-y-auto px-6 py-5 text-left sm:px-8 sm:py-6">
-              <h3 className="text-xl font-semibold text-slate-900 sm:text-2xl">{activeProduct.name}</h3>
-              <p className="text-sm font-medium text-indigo-600 sm:text-base">{activeProduct.price}</p>
-              <p className="break-words text-sm leading-relaxed text-slate-600 sm:text-base">
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-50 sm:text-2xl">{activeProduct.name}</h3>
+              <p className="text-sm font-medium text-indigo-600 dark:text-indigo-300 sm:text-base">{activeProduct.price}</p>
+              <p className="break-words text-sm leading-relaxed text-slate-600 dark:text-slate-300 sm:text-base">
                 {activeProduct.description}
               </p>
             </div>

--- a/app/umkm/_components/UmkmDirectory.tsx
+++ b/app/umkm/_components/UmkmDirectory.tsx
@@ -2,12 +2,13 @@
 
 import dynamic from 'next/dynamic';
 import type { ChangeEvent, FormEvent, MouseEvent } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
 import type { Store } from '@/lib/umkm/types';
 import Pagination from '@/components/Pagination';
+import ThemeToggle from '@/components/ThemeToggle';
 
 const ALL_CATEGORY_VALUE = 'Semua kategori';
 const STORES_PER_PAGE = 10;
@@ -25,6 +26,7 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState(ALL_CATEGORY_VALUE);
   const [currentStorePage, setCurrentStorePage] = useState(1);
+  const storeListRef = useRef<HTMLDivElement | null>(null);
 
   const filteredStores = useMemo(() => {
     return initialStores.filter((store) => {
@@ -67,6 +69,16 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
       setCurrentStorePage(totalStorePages);
     }
   }, [currentStorePage, totalStorePages]);
+
+  const handleStorePageChange = (page: number) => {
+    setCurrentStorePage(page);
+
+    if (storeListRef.current) {
+      storeListRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
 
   const [formData, setFormData] = useState({
     ownerName: '',
@@ -234,12 +246,12 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
   };
 
   return (
-    <div className="bg-white pb-16 pt-12 text-slate-900">
+    <div className="bg-white pb-16 pt-12 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <Link
             href="/"
-            className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100"
+            className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800/60"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -254,38 +266,42 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
             </svg>
             Kembali ke Beranda
           </Link>
+
+          <div className="w-full sm:w-auto sm:min-w-[220px]">
+            <ThemeToggle />
+          </div>
         </div>
         <div className="mb-12 text-center">
-          <span className="inline-flex rounded-full bg-indigo-100 px-4 py-1 text-sm font-medium text-indigo-700">
+          <span className="inline-flex rounded-full bg-indigo-100 px-4 py-1 text-sm font-medium text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
             Etalase UMKM
           </span>
-          <h1 className="mt-4 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+          <h1 className="mt-4 text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-50 sm:text-4xl">
             Temukan UMKM Inspiratif dari Berbagai Penjuru Nusantara
           </h1>
-          <p className="mt-4 text-base text-slate-600 sm:text-lg">
+          <p className="mt-4 text-base text-slate-600 dark:text-slate-300 sm:text-lg">
             Jelajahi katalog UMKM pilihan kami. Ketuk salah satu toko untuk membuka halaman etalase lengkap
             berisi profil usaha, produk unggulan, dan akses langsung ke kontak mereka.
           </p>
         </div>
 
-        <div className="mb-10 grid gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-sm shadow-slate-200/60 sm:grid-cols-3 sm:items-end">
+        <div className="mb-10 grid gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-sm shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40 sm:grid-cols-3 sm:items-end">
           <label className="flex flex-col gap-2 sm:col-span-2">
-            <span className="text-sm font-medium text-slate-700">Cari toko atau kata kunci</span>
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Cari toko atau kata kunci</span>
             <input
               type="search"
               value={searchTerm}
               onChange={(event) => setSearchTerm(event.target.value)}
               placeholder="Misal: kopi, batik, Yogyakarta"
-              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
             />
           </label>
 
           <label className="flex flex-col gap-2">
-            <span className="text-sm font-medium text-slate-700">Filter kategori</span>
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Filter kategori</span>
             <select
               value={selectedCategory}
               onChange={(event) => setSelectedCategory(event.target.value)}
-              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
             >
               <option value={ALL_CATEGORY_VALUE}>Semua kategori</option>
               {categories.map((category) => (
@@ -297,15 +313,16 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
           </label>
         </div>
 
-        {filteredStores.length > 0 ? (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-6">
-            {paginatedStores.map((store) => (
+        <div ref={storeListRef}>
+          {filteredStores.length > 0 ? (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-6">
+              {paginatedStores.map((store) => (
               <Link
                 key={store.id}
                 href={`/umkm/${store.id}`}
-                className="group flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-slate-200/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="group flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-slate-200/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:bg-slate-900 dark:hover:shadow-slate-900/60 dark:focus-visible:ring-offset-slate-950"
               >
-                <div className="relative h-32 w-full overflow-hidden bg-slate-100">
+                <div className="relative h-32 w-full overflow-hidden bg-slate-100 dark:bg-slate-800">
                   <Image
                     src={store.heroImage}
                     alt={store.name}
@@ -317,11 +334,11 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
                 </div>
                 <div className="flex flex-1 flex-col justify-between px-4 py-3 text-left">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">{store.category}</p>
-                    <h2 className="mt-1 text-sm font-semibold text-slate-900 sm:text-base">{store.name}</h2>
-                    <p className="mt-1 line-clamp-2 text-xs text-slate-600 sm:text-sm">{store.tagline}</p>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">{store.category}</p>
+                    <h2 className="mt-1 text-sm font-semibold text-slate-900 dark:text-slate-100 sm:text-base">{store.name}</h2>
+                    <p className="mt-1 line-clamp-2 text-xs text-slate-600 dark:text-slate-300 sm:text-sm">{store.tagline}</p>
                   </div>
-                  <p className="mt-3 flex items-center gap-1 text-xs font-medium text-slate-500">
+                  <p className="mt-3 flex items-center gap-1 text-xs font-medium text-slate-500 dark:text-slate-400">
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 24 24"
@@ -342,51 +359,52 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
                   </p>
                 </div>
               </Link>
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center text-slate-600">
-            <p className="text-base font-semibold text-slate-800">Hmm, belum ada hasil yang cocok.</p>
-            <p className="mt-2 text-sm">
-              Coba ubah kata kunci pencarian atau pilih kategori lain untuk menemukan UMKM yang Anda butuhkan.
-            </p>
-          </div>
-        )}
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-10 text-center text-slate-600 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-300">
+              <p className="text-base font-semibold text-slate-800 dark:text-slate-100">Hmm, belum ada hasil yang cocok.</p>
+              <p className="mt-2 text-sm">
+                Coba ubah kata kunci pencarian atau pilih kategori lain untuk menemukan UMKM yang Anda butuhkan.
+              </p>
+            </div>
+          )}
+        </div>
 
         {filteredStores.length > STORES_PER_PAGE ? (
           <Pagination
             currentPage={currentStorePage}
             totalPages={totalStorePages}
-            onPageChange={setCurrentStorePage}
+            onPageChange={handleStorePageChange}
           />
         ) : (
           null
         )}
 
-        <section className="mt-16 rounded-3xl border border-slate-200 bg-gradient-to-br from-indigo-50 via-white to-cyan-50 p-8 shadow-sm shadow-indigo-100/70 sm:p-12">
+        <section className="mt-16 rounded-3xl border border-slate-200 bg-gradient-to-br from-indigo-50 via-white to-cyan-50 p-8 shadow-sm shadow-indigo-100/70 dark:border-slate-700 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900 dark:shadow-slate-900/40 sm:p-12">
           <div className="mx-auto max-w-3xl text-center">
-            <h2 className="text-2xl font-semibold text-slate-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-50 sm:text-3xl">
               Daftarkan UMKM Anda ke dalam Katalog Kami
             </h2>
-            <p className="mt-3 text-sm text-slate-600 sm:text-base">
+            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300 sm:text-base">
               Ceritakan lebih jauh tentang usaha Anda melalui formulir di bawah ini. Tim kami akan meninjau setiap
               pengajuan dan menghubungi Anda kembali melalui email atau WhatsApp.
             </p>
-            <p className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-left text-sm text-amber-700">
+            <p className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-left text-sm text-amber-700 dark:border-amber-400/40 dark:bg-amber-900/20 dark:text-amber-200">
               <strong className="font-semibold">Catatan gambar:</strong> cantumkan tautan drive, folder, atau marketplace
               yang berisi foto produk Anda. Kami tidak menerima unggahan file langsung agar tetap ringan bagi penyimpanan.
             </p>
           </div>
 
           <div className="mx-auto mt-10 flex max-w-xl flex-col items-center gap-4 text-center">
-            <p className="text-sm text-slate-600 sm:text-base">
+            <p className="text-sm text-slate-600 dark:text-slate-300 sm:text-base">
               Tekan tombol di bawah ini untuk membuka formulir pengajuan. Anda dapat menggulir isi formulir secara nyaman,
               termasuk saat diakses melalui ponsel.
             </p>
             <button
               type="button"
               onClick={openFormModal}
-              className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-600/40 transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 focus:ring-offset-2 focus:ring-offset-indigo-100"
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-600/40 transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 focus:ring-offset-2 focus:ring-offset-indigo-100 dark:focus:ring-offset-slate-900"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -413,13 +431,13 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
               role="dialog"
               aria-modal="true"
               aria-labelledby="umkm-submission-title"
-              className="relative w-full max-w-3xl rounded-3xl border border-slate-200 bg-white shadow-2xl shadow-slate-900/20"
+              className="relative w-full max-w-3xl rounded-3xl border border-slate-200 bg-white shadow-2xl shadow-slate-900/20 dark:border-slate-700 dark:bg-slate-950"
               onClick={(event) => event.stopPropagation()}
             >
               <button
                 type="button"
                 onClick={closeFormModal}
-                className="absolute right-4 top-4 inline-flex items-center justify-center rounded-full border border-slate-200 bg-white p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 focus:ring-offset-2"
+                className="absolute right-4 top-4 inline-flex items-center justify-center rounded-full border border-slate-200 bg-white p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 focus:ring-offset-2 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100 dark:focus:ring-offset-slate-900"
                 aria-label="Tutup formulir UMKM"
               >
                 <svg
@@ -437,10 +455,10 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
 
               <div className="max-h-[min(90vh,48rem)] overflow-y-auto px-6 py-10 sm:px-10">
                 <div className="mx-auto max-w-2xl text-left">
-                  <h2 id="umkm-submission-title" className="text-2xl font-semibold text-slate-900 sm:text-3xl">
+                  <h2 id="umkm-submission-title" className="text-2xl font-semibold text-slate-900 dark:text-slate-50 sm:text-3xl">
                     Formulir Pengajuan UMKM
                   </h2>
-                  <p className="mt-3 text-sm text-slate-600 sm:text-base">
+                  <p className="mt-3 text-sm text-slate-600 dark:text-slate-300 sm:text-base">
                     Lengkapi informasi berikut agar tim kurasi kami dapat memproses dan menampilkan UMKM Anda di Ruang Riung.
                     Semua kolom dapat digulir dan tetap nyaman dibaca, termasuk pada layar ponsel.
                   </p>
@@ -449,59 +467,59 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
                 <form className="mx-auto mt-8 grid max-w-2xl gap-6" onSubmit={handleSubmit}>
                   <div className="grid gap-6 sm:grid-cols-2">
                     <label className="flex flex-col gap-2 text-left">
-                      <span className="text-sm font-medium text-slate-700">Nama penanggung jawab</span>
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Nama penanggung jawab</span>
                       <input
                         type="text"
                         name="ownerName"
                         value={formData.ownerName}
                         onChange={handleInputChange}
                         required
-                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                       />
                     </label>
                     <label className="flex flex-col gap-2 text-left">
-                      <span className="text-sm font-medium text-slate-700">Email aktif</span>
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Email aktif</span>
                       <input
                         type="email"
                         name="email"
                         value={formData.email}
                         onChange={handleInputChange}
                         required
-                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                       />
                     </label>
                     <label className="flex flex-col gap-2 text-left">
-                      <span className="text-sm font-medium text-slate-700">Nomor WhatsApp</span>
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Nomor WhatsApp</span>
                       <input
                         type="tel"
                         name="whatsapp"
                         value={formData.whatsapp}
                         onChange={handleInputChange}
                         placeholder="Contoh: 6281234567890"
-                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                       />
                     </label>
                     <label className="flex flex-col gap-2 text-left">
-                      <span className="text-sm font-medium text-slate-700">Nama UMKM</span>
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Nama UMKM</span>
                       <input
                         type="text"
                         name="businessName"
                         value={formData.businessName}
                         onChange={handleInputChange}
                         required
-                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                       />
                     </label>
                   </div>
 
                   <div className="grid gap-6 sm:grid-cols-2">
                     <label className="flex flex-col gap-2 text-left">
-                      <span className="text-sm font-medium text-slate-700">Kategori utama</span>
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Kategori utama</span>
                       <select
                         name="businessCategory"
                         value={formData.businessCategory}
                         onChange={handleInputChange}
-                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                       >
                         <option value="">Pilih kategori</option>
                         {categories.map((category) => (
@@ -514,7 +532,7 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
                     </label>
                     {formData.businessCategory === 'Kategori lainnya' && (
                       <label className="flex flex-col gap-2 text-left sm:col-span-2">
-                        <span className="text-sm font-medium text-slate-700">Tuliskan kategori usaha</span>
+                        <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Tuliskan kategori usaha</span>
                         <input
                           type="text"
                           name="customBusinessCategory"
@@ -522,75 +540,75 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
                           onChange={handleInputChange}
                           required
                           placeholder="Contoh: Kuliner sehat, Jasa desain interior, dsb."
-                          className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                          className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                         />
                       </label>
                     )}
                     <label className="flex flex-col gap-2 text-left">
-                      <span className="text-sm font-medium text-slate-700">Domisili usaha</span>
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Domisili usaha</span>
                       <input
                         type="text"
                         name="location"
                         value={formData.location}
                         onChange={handleInputChange}
                         placeholder="Kota/Kabupaten, Provinsi"
-                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                        className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                       />
                     </label>
                   </div>
 
                   <label className="flex flex-col gap-2 text-left">
-                    <span className="text-sm font-medium text-slate-700">Deskripsi singkat usaha</span>
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Deskripsi singkat usaha</span>
                     <textarea
                       name="description"
                       value={formData.description}
                       onChange={handleInputChange}
                       required
                       rows={4}
-                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                     />
                   </label>
 
                   <label className="flex flex-col gap-2 text-left">
-                    <span className="text-sm font-medium text-slate-700">Sorotan produk/jasa</span>
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Sorotan produk/jasa</span>
                     <textarea
                       name="productHighlights"
                       value={formData.productHighlights}
                       onChange={handleInputChange}
                       rows={4}
                       placeholder="Ceritakan produk unggulan atau layanan utama"
-                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                     />
                   </label>
 
                   <label className="flex flex-col gap-2 text-left">
-                    <span className="text-sm font-medium text-slate-700">Tautan gambar atau katalog</span>
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Tautan gambar atau katalog</span>
                     <input
                       type="url"
                       name="imageLinks"
                       value={formData.imageLinks}
                       onChange={handleInputChange}
                       placeholder="Contoh: https://drive.google.com/your-folder"
-                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                     />
                   </label>
 
                   <label className="flex flex-col gap-2 text-left">
-                    <span className="text-sm font-medium text-slate-700">Informasi tambahan</span>
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Informasi tambahan</span>
                     <textarea
                       name="additionalInfo"
                       value={formData.additionalInfo}
                       onChange={handleInputChange}
                       rows={4}
                       placeholder="Berikan informasi tambahan seperti promo, jam operasional, dsb."
-                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                      className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                     />
                   </label>
 
                   <div className="flex flex-col gap-4 text-left">
-                    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-                      <p className="font-medium text-slate-700">Verifikasi keamanan</p>
-                      <p className="mt-1 text-xs text-slate-500">
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                      <p className="font-medium text-slate-700 dark:text-slate-200">Verifikasi keamanan</p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                         Centang captcha Cloudflare Turnstile di bawah ini sebelum mengirimkan formulir.
                       </p>
                       <div className="mt-4">
@@ -605,7 +623,7 @@ export function UmkmDirectory({ stores: initialStores, categories }: UmkmDirecto
                     <button
                       type="submit"
                       disabled={formStatus === 'loading'}
-                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-600/40 transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 focus:ring-offset-2 focus:ring-offset-indigo-100 disabled:cursor-not-allowed disabled:opacity-70"
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-600/40 transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 focus:ring-offset-2 focus:ring-offset-indigo-100 dark:focus:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-70"
                     >
                       {formStatus === 'loading' ? (
                         <>


### PR DESCRIPTION
## Summary
- add reusable theme toggle to UMKM listing and detail pages and restyle both views for dark mode support
- enhance UMKM directory pagination to scroll the listing back into view for better navigation
- extend UMKM directory and store showcase components with dark-friendly colors and focus states

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d506496b7c832eb01364c466743457