### PR TITLE
Improve prompt directory search filters

### DIFF
--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -8,7 +8,7 @@ import PromptSubmissionTrigger from '../../components/PromptSubmissionTrigger';
 import Pagination from '../../components/Pagination';
 import AdBanner from '../../components/AdBanner';
 import { PROMPT_BOTTOM_AD_SLOT, PROMPT_TOP_AD_SLOT } from '../../lib/adsense';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Filter, Search, XCircle } from 'lucide-react';
 import { usePromptSuggestions } from './usePromptSuggestions';
 
 const PROMPTS_PER_PAGE = 9;
@@ -47,6 +47,7 @@ export default function PromptClient({ prompts }: PromptClientProps) {
   const [promptList, setPromptList] = useState(() => sortPrompts(prompts));
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState('');
+  const [selectedTool, setSelectedTool] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -62,10 +63,25 @@ export default function PromptClient({ prompts }: PromptClientProps) {
   const allTags = useMemo(() => {
     const tags = new Set<string>();
     promptList.forEach(p => p.tags.forEach(t => tags.add(t)));
-    return Array.from(tags);
+    return Array.from(tags).sort((a, b) => a.localeCompare(b, 'id'));
+  }, [promptList]);
+
+  const allTools = useMemo(() => {
+    const tools = new Set<string>();
+    promptList.forEach(p => {
+      if (p.tool) {
+        tools.add(p.tool);
+      }
+    });
+    return Array.from(tools).sort((a, b) => a.localeCompare(b, 'id'));
   }, [promptList]);
 
   const suggestions = usePromptSuggestions(promptList, searchTerm);
+
+  const hasActiveFilters = useMemo(
+    () => Boolean(searchTerm.trim() || selectedTag || selectedTool),
+    [searchTerm, selectedTag, selectedTool],
+  );
 
   const scrollToPromptListTop = useCallback(() => {
     if (typeof window === 'undefined') {
@@ -89,7 +105,7 @@ export default function PromptClient({ prompts }: PromptClientProps) {
     if (hasInteractedWithPaginationRef.current) {
       scrollToPromptListTop();
     }
-  }, [searchTerm, selectedTag, scrollToPromptListTop]);
+  }, [searchTerm, selectedTag, selectedTool, scrollToPromptListTop]);
 
   useEffect(() => () => {
     if (blurTimeoutRef.current) {
@@ -120,10 +136,11 @@ export default function PromptClient({ prompts }: PromptClientProps) {
         : true;
 
       const matchesTag = selectedTag ? prompt.tags.includes(selectedTag) : true;
+      const matchesTool = selectedTool ? prompt.tool === selectedTool : true;
 
-      return matchesSearch && matchesTag;
+      return matchesSearch && matchesTag && matchesTool;
     });
-  }, [searchTerm, selectedTag, promptList]);
+  }, [searchTerm, selectedTag, selectedTool, promptList]);
 
   const paginatedPrompts = useMemo(() => {
     const startIndex = (currentPage - 1) * PROMPTS_PER_PAGE;
@@ -171,6 +188,16 @@ export default function PromptClient({ prompts }: PromptClientProps) {
     scrollToPromptListTop();
   };
 
+  const handleResetFilters = useCallback(() => {
+    setSearchTerm('');
+    setSelectedTag('');
+    setSelectedTool('');
+    setShowSuggestions(false);
+    hasInteractedWithPaginationRef.current = true;
+    setCurrentPage(1);
+    scrollToPromptListTop();
+  }, [scrollToPromptListTop]);
+
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8 flex justify-center">
@@ -191,52 +218,110 @@ export default function PromptClient({ prompts }: PromptClientProps) {
         />
       </div>
 
-      <div className="mb-8 p-4 bg-gray-100 dark:bg-gray-800 rounded-lg">
-        <div className="flex flex-col md:flex-row gap-4">
-          <div className="relative flex-grow">
-            <input
-              type="text"
-              placeholder="Cari berdasarkan judul, penulis, atau isi..."
-              value={searchTerm}
-              onChange={e => handleSearchChange(e.target.value)}
-              onFocus={handleInputFocus}
-              onBlur={handleInputBlur}
-              className="flex-grow w-full p-3 border border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600"
-            />
-            {shouldShowSuggestions && (
-              <ul className="absolute z-20 mt-1 w-full overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800">
-                {suggestions.map(suggestion => (
-                  <li key={`${suggestion.type}-${suggestion.value}`} className="border-b border-gray-100 last:border-0 dark:border-gray-700">
-                    <button
-                      type="button"
-                      className="w-full px-4 py-2 text-left text-sm hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
-                      onMouseDown={event => {
-                        event.preventDefault();
-                        handleSuggestionSelect(suggestion.value);
-                      }}
-                    >
-                      <div className="font-medium text-gray-800 dark:text-gray-100">
-                        {highlightMatches(suggestion.value, searchTerm)}
-                      </div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
-                        {suggestion.type === 'title' ? 'Judul' : 'Penulis'} • {suggestion.occurrences} kecocokan
-                      </div>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
+      <div className="mb-10 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300">
+              <Filter className="h-5 w-5" />
+            </span>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Temukan Prompt yang Tepat</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Gunakan pencarian, filter tag, dan alat untuk mempersempit pilihan Anda.
+              </p>
+            </div>
           </div>
-          <select
-            value={selectedTag}
-            onChange={e => setSelectedTag(e.target.value)}
-            className="p-3 border border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600"
-          >
-            <option value="">Semua Tag</option>
-            {allTags.map(tag => (
-              <option key={tag} value={tag}>{tag}</option>
-            ))}
-          </select>
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={handleResetFilters}
+              className="inline-flex items-center gap-2 rounded-full border border-transparent bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              <XCircle className="h-4 w-4" />
+              Atur Ulang
+            </button>
+          )}
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div className="md:col-span-2 lg:col-span-2">
+            <label htmlFor="prompt-search" className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200">
+              Kata Kunci
+            </label>
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400">
+                <Search className="h-4 w-4" />
+              </span>
+              <input
+                id="prompt-search"
+                type="text"
+                placeholder="Cari judul, penulis, atau isi prompt..."
+                value={searchTerm}
+                onChange={e => handleSearchChange(e.target.value)}
+                onFocus={handleInputFocus}
+                onBlur={handleInputBlur}
+                className="w-full rounded-lg border border-gray-300 bg-white px-10 py-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+              />
+              {shouldShowSuggestions && (
+                <ul className="absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-800">
+                  {suggestions.map(suggestion => (
+                    <li key={`${suggestion.type}-${suggestion.value}`} className="border-b border-gray-100 last:border-0 dark:border-gray-700">
+                      <button
+                        type="button"
+                        className="w-full px-4 py-2 text-left text-sm text-gray-700 transition hover:bg-gray-100 focus:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                        onMouseDown={event => {
+                          event.preventDefault();
+                          handleSuggestionSelect(suggestion.value);
+                        }}
+                      >
+                        <div className="font-medium text-gray-800 dark:text-gray-100">
+                          {highlightMatches(suggestion.value, searchTerm)}
+                        </div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400">
+                          {suggestion.type === 'title' ? 'Judul' : 'Penulis'} • {suggestion.occurrences} kecocokan
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+          <div>
+            <label htmlFor="prompt-tag" className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200">
+              Tag
+            </label>
+            <select
+              id="prompt-tag"
+              value={selectedTag}
+              onChange={e => setSelectedTag(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+            >
+              <option value="">Semua Tag</option>
+              {allTags.map(tag => (
+                <option key={tag} value={tag}>
+                  {tag}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="prompt-tool" className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200">
+              Alat
+            </label>
+            <select
+              id="prompt-tool"
+              value={selectedTool}
+              onChange={e => setSelectedTool(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+            >
+              <option value="">Semua Alat</option>
+              {allTools.map(tool => (
+                <option key={tool} value={tool}>
+                  {tool}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- redesign the prompt directory search area with a descriptive header, keyword input enhancements, and suggestion styling for a more polished look
- add tag and tool dropdown filters with reset handling and alphabetized options to refine prompt discovery
- ensure pagination resets when filters change so results stay in sync

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b589c1c0832e896b2d0e02db355c