### PR TITLE
Fix internal artikel cross-links

### DIFF
--- a/content/articles-md/cuan-rencana-workflow-codex-github-vercel-adsense.md
+++ b/content/articles-md/cuan-rencana-workflow-codex-github-vercel-adsense.md
@@ -12,7 +12,7 @@ Cuan bukan sekadar kata ajaib; ia adalah denyut nadi yang membuat saya menyalaka
 
 ## Bab 1: Menyapa Codex sebagai Rekan Satu Tim
 
-Saya selalu memulai cerita ini dengan memperkenalkan Codex yang hidup di fitur ChatGPT. Ia bukan sekadar mesin; ia bagai rekan satu tim yang sabar. Kita bisa memintanya membuat kerangka Next.js, membantu menulis API routes, atau menjelaskan konsep TypeScript ketika kepala sedang penuh. Untuk menggali lebih dalam tentang cara kerja Codex di ekosistem RuangRiung, sempatkan membaca [panduan menulis prompt JSON](/articles/panduan-menulis-prompt-json) yang mengajarkan bagaimana mengubah kebutuhan manusiawi menjadi instruksi jelas bagi mesin.
+Saya selalu memulai cerita ini dengan memperkenalkan Codex yang hidup di fitur ChatGPT. Ia bukan sekadar mesin; ia bagai rekan satu tim yang sabar. Kita bisa memintanya membuat kerangka Next.js, membantu menulis API routes, atau menjelaskan konsep TypeScript ketika kepala sedang penuh. Untuk menggali lebih dalam tentang cara kerja Codex di ekosistem RuangRiung, sempatkan membaca [panduan menulis prompt JSON](/artikel/panduan-menulis-prompt-json) yang mengajarkan bagaimana mengubah kebutuhan manusiawi menjadi instruksi jelas bagi mesin.
 
 Ajak Codex berdialog hangat. Contohnya, saya sering menulis, "Codex, tolong buatkan halaman landing bertema produktivitas dengan hero, daftar fitur, dan form berlangganan." Responnya menjadi titik awal kita menata kode secara rapi.
 
@@ -26,7 +26,7 @@ Bayangkan ruang kerja yang harum kopi dan ditemani playlist favorit. Agar cerita
 4. **Jalankan `pnpm install`** untuk memasang dependensi.
 5. **Uji aplikasi lokal** dengan `pnpm dev` dan buka `http://localhost:3000` sambil mengecek pengalaman pengguna.
 
-Jika ingin memahami bagaimana konten bisa tampil konsisten di berbagai perangkat, Anda dapat menengok [mengenal fitur PWA](/articles/mengenal-fitur-pwa) yang menyoroti aspek performa dan caching.
+Jika ingin memahami bagaimana konten bisa tampil konsisten di berbagai perangkat, Anda dapat menengok [mengenal fitur PWA](/artikel/mengenal-fitur-pwa) yang menyoroti aspek performa dan caching.
 
 ## Bab 3: Mengarsipkan Kisah di GitHub
 
@@ -42,7 +42,7 @@ Di GitHub saya merasa memiliki galeri yang menyimpan setiap momen kecil. Setiap 
    git push -u origin main
    ```
 3. **Aktifkan proteksi branch** agar perubahan besar menempuh proses review.
-4. **Gunakan Issues dan Projects** sebagai papan perasaan: catat ide, bug, dan milestone. Teknik mengelola prioritas juga dibahas dalam [mengupas algoritma Facebook Pro](/articles/mengupas-algoritma-facebook-pro) yang relevan untuk perencanaan konten lintas kanal.
+4. **Gunakan Issues dan Projects** sebagai papan perasaan: catat ide, bug, dan milestone. Teknik mengelola prioritas juga dibahas dalam [mengupas algoritma Facebook Pro](/artikel/mengupas-algoritma-facebook-pro) yang relevan untuk perencanaan konten lintas kanal.
 
 ## Bab 4: Menyulap GitHub Menjadi Website Lewat Vercel
 
@@ -54,13 +54,13 @@ Saat pertama kali menekan tombol deploy di Vercel, saya selalu merasakan gemetar
 4. **Pantau log build** sambil menyeruput minuman favorit. Jika ada error, ajak Codex mencari solusinya.
 5. **Bagikan URL preview** kepada teman atau komunitas RuangRiung untuk mendapat umpan balik emosional sekaligus teknis.
 
-Untuk memperdalam strategi optimasi interaksi pengguna, Anda bisa membaca [tips fitur edit gambar real-time](/articles/tips-fitur-edit-gambar-real-time) yang mengupas performa front-end.
+Untuk memperdalam strategi optimasi interaksi pengguna, Anda bisa membaca [tips fitur edit gambar real-time](/artikel/tips-fitur-edit-gambar-real-time) yang mengupas performa front-end.
 
 ## Bab 5: Mempersiapkan Website Menyambut AdSense
 
 Sebelum mengajukan AdSense, saya memastikan website terasa seperti rumah nyaman bagi pengunjung:
 
-- **Isi dengan konten orisinal** yang konsisten. Rangkai cerita ala [membangun dunia fantasi dengan AI Storyteller](/articles/membangun-dunia-fantasi-anda-dengan-ai-storyteller) agar tiap halaman mengundang rasa penasaran.
+- **Isi dengan konten orisinal** yang konsisten. Rangkai cerita ala [membangun dunia fantasi dengan AI Storyteller](/artikel/membangun-dunia-fantasi-anda-dengan-ai-storyteller) agar tiap halaman mengundang rasa penasaran.
 - **Pastikan navigasi terang benderang**: header, footer, dan sitemap memberi arahan jelas.
 - **Optimalkan kecepatan** menggunakan gambar terkompresi, lazy loading, dan dukungan CDN Vercel.
 - **Sediakan halaman legal** seperti Privacy Policy dan Terms of Service untuk menunjukkan profesionalisme.
@@ -74,7 +74,7 @@ Mengajukan AdSense ibarat mengirim surat cinta yang penuh harapan. Berikut langk
 3. **Verifikasi kepemilikan situs** melalui meta tag atau file HTML yang diunggah ke root.
 4. **Perbarui konten secara berkala** selama masa review (biasanya 3–14 hari) agar Google melihat aktivitas alami.
 
-Jangan lupa meninjau [panduan menilai kualitas gambar AI](/articles/panduan-menilai-kualitas-gambar-ai) untuk memastikan semua aset visual memenuhi standar kualitas yang disukai AdSense.
+Jangan lupa meninjau [panduan menilai kualitas gambar AI](/artikel/panduan-menilai-kualitas-gambar-ai) untuk memastikan semua aset visual memenuhi standar kualitas yang disukai AdSense.
 
 ## Bab 7: Menempatkan Script AdSense Tanpa Merusak Cerita
 
@@ -142,11 +142,11 @@ Perjalanan tidak berhenti setelah iklan tampil. Saya selalu menulis jurnal mingg
 - **Kualitas konten** dengan menggunakan Codex sebagai editor yang mengusulkan perbaikan.
 - **Eksperimen A/B** pada posisi iklan tanpa mengorbankan kenyamanan pengguna.
 
-Lengkapi eksplorasi Anda dengan membaca [menguasai komposisi gambar AI](/articles/menguasai-komposisi-gambar-ai) untuk meningkatkan estetika visual yang mendorong waktu kunjungan lebih lama.
+Lengkapi eksplorasi Anda dengan membaca [menguasai komposisi gambar AI](/artikel/menguasai-komposisi-gambar-ai) untuk meningkatkan estetika visual yang mendorong waktu kunjungan lebih lama.
 
 ## Penutup: Dari Cerita Menjadi Penghasilan
 
 Ketika semua langkah terjalin, saya merasa seperti menutup buku harian dengan senyum. Codex membantu menulis kode, GitHub menjaga histori, Vercel menayangkan karya, dan AdSense memberi apresiasi dalam bentuk pendapatan. Perjalanan ini santai, emosional, namun tetap bertumpu pada prinsip ilmiah. Semoga kisah saya membuat Anda yakin bahwa cuan bukan sekadar fantasi—ia bisa hadir melalui integrasi yang sabar dan konsisten.
 
-Jika Anda membutuhkan versi yang lebih terstruktur dan formal, silakan baca [Strategi Formal Menghubungkan Codex ChatGPT, GitHub, Vercel, dan Google AdSense untuk Cuan Berkelanjutan](/articles/menghubungkan-codex-dari-chatgpt-github-vercel-dan-adsense). Jadikan kedua kisah ini sebagai pasangan kompas: satu menjaga alur emosi, satunya lagi menegakkan langkah sistematis.
+Jika Anda membutuhkan versi yang lebih terstruktur dan formal, silakan baca [Strategi Formal Menghubungkan Codex ChatGPT, GitHub, Vercel, dan Google AdSense untuk Cuan Berkelanjutan](/artikel/menghubungkan-codex-dari-chatgpt-github-vercel-dan-adsense). Jadikan kedua kisah ini sebagai pasangan kompas: satu menjaga alur emosi, satunya lagi menegakkan langkah sistematis.
 

--- a/content/articles-md/menghubungkan-codex-dari-chatgpt-github-vercel-dan-adsense.md
+++ b/content/articles-md/menghubungkan-codex-dari-chatgpt-github-vercel-dan-adsense.md
@@ -8,11 +8,11 @@ image: /v1/assets/ruangriung.png
 summary: Narasi formal namun tetap menggugah tentang cara membangun alur kerja Codex, GitHub, Vercel, dan Google AdSense agar website pribadi memperoleh pendapatan stabil di luar Facebook.
 ---
 
-Bayangkan saya sedang duduk di sebuah sudut kedai kopi, memperhatikan laptop yang menyala dengan penuh harap. Di hadapan saya terbentang pertanyaan yang mungkin juga Anda rasakan: bagaimana caranya mendapatkan penghasilan daring tanpa harus bergantung pada ekosistem Facebook? Melalui artikel ini, saya akan menuntun Anda menapaki setiap tahap integrasi Codex dari fitur ChatGPT dengan GitHub, Vercel, hingga penayangan Google AdSense di website pribadi. Pendekatan yang saya paparkan bersifat formal, runtut, namun tetap memelihara kedekatan emosional agar Anda percaya diri menjalankan seluruh proses. Jika Anda membutuhkan narasi pendamping yang lebih santai, silakan jelajahi [Cuan Mengalir Terus Tanpa Batasan Algoritma](/articles/cuan-rencana-workflow-codex-github-vercel-adsense) sebagai pasangan bacaan yang saling menguatkan.
+Bayangkan saya sedang duduk di sebuah sudut kedai kopi, memperhatikan laptop yang menyala dengan penuh harap. Di hadapan saya terbentang pertanyaan yang mungkin juga Anda rasakan: bagaimana caranya mendapatkan penghasilan daring tanpa harus bergantung pada ekosistem Facebook? Melalui artikel ini, saya akan menuntun Anda menapaki setiap tahap integrasi Codex dari fitur ChatGPT dengan GitHub, Vercel, hingga penayangan Google AdSense di website pribadi. Pendekatan yang saya paparkan bersifat formal, runtut, namun tetap memelihara kedekatan emosional agar Anda percaya diri menjalankan seluruh proses. Jika Anda membutuhkan narasi pendamping yang lebih santai, silakan jelajahi [Cuan Mengalir Terus Tanpa Batasan Algoritma](/artikel/cuan-rencana-workflow-codex-github-vercel-adsense) sebagai pasangan bacaan yang saling menguatkan.
 
 ## Episode 1: Memahami Peran Codex dalam Proses Kreatif
 
-Codex merupakan mitra penulisan kode yang dihadirkan dalam mode ChatGPT dengan kemampuan coding. Ia membantu menyusun fondasi proyek, menuliskan komponen, serta menghasilkan dokumentasi dasar. Agar pemanfaatannya optimal, pastikan Anda memahami struktur aplikasi, alur kerja Git, serta konsep deployment modern. Untuk memperkaya pemahaman konseptual, Anda dapat meninjau ulasan kami mengenai [mengupas tuntas fitur RuangRiung Generator](/articles/mengupas-tuntas-fitur-ruangriung-generator) yang memaparkan ekosistem platform secara menyeluruh.
+Codex merupakan mitra penulisan kode yang dihadirkan dalam mode ChatGPT dengan kemampuan coding. Ia membantu menyusun fondasi proyek, menuliskan komponen, serta menghasilkan dokumentasi dasar. Agar pemanfaatannya optimal, pastikan Anda memahami struktur aplikasi, alur kerja Git, serta konsep deployment modern. Untuk memperkaya pemahaman konseptual, Anda dapat meninjau ulasan kami mengenai [mengupas tuntas fitur RuangRiung Generator](/artikel/mengupas-tuntas-fitur-ruangriung-generator) yang memaparkan ekosistem platform secara menyeluruh.
 
 Saya biasanya memulai dengan meminta Codex membuat prototipe halaman arahan sederhana: "Codex, bantu saya membangun landing page blog teknologi dengan navigasi, hero section, dan daftar artikel." Hasilnya mungkin belum sempurna, tetapi cukup untuk memantik rasa percaya diri bahwa pondasi telah terbentuk.
 
@@ -23,7 +23,7 @@ Sebelum kode dikirim ke GitHub, lengkapi studio kerja di perangkat lokal. Anggap
 1. **Pasang Node.js beserta pengelola paket (pnpm, npm, atau yarn).** Versi LTS memberikan kestabilan yang lebih tinggi.
 2. **Buat folder proyek**, misalnya `ruang-codex`, untuk menampung semua aset.
 3. **Inisialisasi repositori Git.** Jalankan `git init`, susun `.gitignore`, dan buat `README.md` untuk mencatat catatan awal.
-4. **Masukkan kode dari Codex** ke struktur Next.js standar: direktori `app` atau `pages`, `components`, serta `public` untuk aset statis. Panduan serupa juga dibahas di artikel [mengenal fitur PWA](/articles/mengenal-fitur-pwa) guna memastikan struktur aplikasi tetap efisien.
+4. **Masukkan kode dari Codex** ke struktur Next.js standar: direktori `app` atau `pages`, `components`, serta `public` untuk aset statis. Panduan serupa juga dibahas di artikel [mengenal fitur PWA](/artikel/mengenal-fitur-pwa) guna memastikan struktur aplikasi tetap efisien.
 5. **Jalankan penginstalan dependensi** menggunakan `pnpm install` (atau perintah setara pada pengelola paket lain).
 6. **Uji proyek secara lokal** melalui `pnpm dev` dan akses `http://localhost:3000`.
 
@@ -41,7 +41,7 @@ GitHub menjadi arsip historis perjalanan proyek Anda. Setiap commit menghadirkan
    git push -u origin main
    ```
 3. **Aktifkan proteksi branch** untuk mencegah perubahan tergesa-gesa langsung masuk ke cabang utama.
-4. **Manfaatkan GitHub Issues dan Projects** sebagai papan kendali tugas. Referensi mengenai perencanaan konten dan otomasi juga tersedia di artikel [mengupas algoritma Facebook Pro](/articles/mengupas-algoritma-facebook-pro) yang menekankan pentingnya penjadwalan strategis.
+4. **Manfaatkan GitHub Issues dan Projects** sebagai papan kendali tugas. Referensi mengenai perencanaan konten dan otomasi juga tersedia di artikel [mengupas algoritma Facebook Pro](/artikel/mengupas-algoritma-facebook-pro) yang menekankan pentingnya penjadwalan strategis.
 
 ## Episode 4: Deploy Tanpa Hambatan dengan Vercel
 
@@ -53,13 +53,13 @@ Vercel merupakan platform deployment yang ramah bagi aplikasi Next.js. Setiap ri
 4. **Tambahkan environment variable** jika proyek Anda memerlukan API key atau konfigurasi rahasia.
 5. **Lakukan deployment** dan manfaatkan URL preview otomatis untuk mengumpulkan umpan balik tim.
 
-Untuk memahami aspek performa front-end, Anda bisa membaca artikel [tips fitur edit gambar real-time](/articles/tips-fitur-edit-gambar-real-time) yang menyoroti optimasi interaksi pengguna.
+Untuk memahami aspek performa front-end, Anda bisa membaca artikel [tips fitur edit gambar real-time](/artikel/tips-fitur-edit-gambar-real-time) yang menyoroti optimasi interaksi pengguna.
 
 ## Episode 5: Menata Website agar Siap Monetisasi
 
 Sebelum mengajukan AdSense, situs perlu memenuhi standar kualitas konten dan pengalaman pengguna.
 
-- **Publikasikan konten orisinal secara rutin.** Anda dapat mengikuti pendekatan struktur narasi yang dijelaskan dalam [membangun dunia fantasi dengan AI Storyteller](/articles/membangun-dunia-fantasi-anda-dengan-ai-storyteller) untuk menjaga konsistensi storytelling.
+- **Publikasikan konten orisinal secara rutin.** Anda dapat mengikuti pendekatan struktur narasi yang dijelaskan dalam [membangun dunia fantasi dengan AI Storyteller](/artikel/membangun-dunia-fantasi-anda-dengan-ai-storyteller) untuk menjaga konsistensi storytelling.
 - **Pastikan navigasi jelas** dengan header, footer, serta sitemap yang mudah diakses.
 - **Optimalkan kecepatan halaman.** Manfaatkan komponen `<Image>` Next.js dan fitur caching Vercel.
 - **Siapkan halaman legal** seperti Privacy Policy, Terms of Service, dan kontak.
@@ -70,7 +70,7 @@ Proses pendaftaran AdSense memerlukan ketelitian administratif. Persiapkan domai
 
 1. **Daftarkan diri di Google AdSense** menggunakan akun Google utama.
 2. **Masukkan detail website** beserta domain custom yang telah diarahkan ke deployment Vercel.
-3. **Verifikasi kepemilikan situs** melalui meta tag atau file HTML. Anda dapat memanfaatkan pendekatan dokumentasi yang dijelaskan pada [panduan menilai kualitas gambar AI](/articles/panduan-menilai-kualitas-gambar-ai) untuk memastikan struktur metadata tetap rapi.
+3. **Verifikasi kepemilikan situs** melalui meta tag atau file HTML. Anda dapat memanfaatkan pendekatan dokumentasi yang dijelaskan pada [panduan menilai kualitas gambar AI](/artikel/panduan-menilai-kualitas-gambar-ai) untuk memastikan struktur metadata tetap rapi.
 4. **Menunggu proses tinjauan**, biasanya 2–14 hari. Tetap perbarui konten untuk menunjukkan aktivitas organik.
 
 ## Episode 7: Menyematkan Script AdSense di Next.js
@@ -124,7 +124,7 @@ Setelah disetujui, letakkan kode AdSense di aplikasi Next.js Anda dengan langkah
      {`(adsbygoogle = window.adsbygoogle || []).push({});`}
    </Script>
    ```
-   Letakkan setelah paragraf tertentu atau di sidebar agar tidak mengganggu pengalaman membaca. Pendekatan keseimbangan konten dan monetisasi juga kami bahas di [mengoptimalkan konten Facebook dan website](/articles/cara-mengoptimalkan-konten-facebook-dan-website-anda).
+   Letakkan setelah paragraf tertentu atau di sidebar agar tidak mengganggu pengalaman membaca. Pendekatan keseimbangan konten dan monetisasi juga kami bahas di [mengoptimalkan konten Facebook dan website](/artikel/cara-mengoptimalkan-konten-facebook-dan-website-anda).
 
 ## Episode 8: Mengelola Analitik dan Pertumbuhan Traffic
 
@@ -132,7 +132,7 @@ Monetisasi akan efektif apabila didukung aliran pengunjung yang sehat.
 
 - **Integrasikan Google Analytics 4** untuk memantau perilaku pengguna.
 - **Gunakan Google Search Console** dan unggah sitemap (`https://domain.com/sitemap.xml`).
-- **Terapkan optimasi SEO** melalui meta tag, struktur heading, serta schema markup. Rujuk artikel [tips membuat prompt efektif](/articles/tips-membuat-prompt-efektif) guna merancang konten berbasis data kata kunci.
+- **Terapkan optimasi SEO** melalui meta tag, struktur heading, serta schema markup. Rujuk artikel [tips membuat prompt efektif](/artikel/tips-membuat-prompt-efektif) guna merancang konten berbasis data kata kunci.
 - **Bangun komunitas di luar Facebook** melalui newsletter, forum, atau grup Telegram.
 
 ## Episode 9: Menjaga Keberlanjutan Proyek
@@ -141,7 +141,7 @@ Website yang monetisasinya konsisten memerlukan perawatan berkala.
 
 - **Perbarui dependensi** dan uji di branch terpisah sebelum digabungkan.
 - **Evaluasi performa iklan** untuk menyesuaikan posisi yang paling efektif.
-- **Eksplorasi fitur baru** seperti newsletter atau e-book gratis sebagai pintu masuk funnel. Strategi retensi serupa juga diulas di [memaksimalkan asisten prompt](/articles/memaksimalkan-asisten-prompt).
+- **Eksplorasi fitur baru** seperti newsletter atau e-book gratis sebagai pintu masuk funnel. Strategi retensi serupa juga diulas di [memaksimalkan asisten prompt](/artikel/memaksimalkan-asisten-prompt).
 - **Manfaatkan GitHub Actions** untuk otomatisasi linting, testing, dan build preview.
 
 ## Episode 10: Meneguhkan Mindset Jangka Panjang


### PR DESCRIPTION
## Summary
- update internal cross-links in the Codex monetisation articles to use the correct `/artikel/` path prefix so they resolve properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b142eee0832ead9502167762eb41