### PR TITLE
Add image link for Chibi Punk prompt

### DIFF
--- a/content/prompts/prompt-131.md
+++ b/content/prompts/prompt-131.md
@@ -5,6 +5,7 @@ title: "Chibi Punk"
 author: "Guntur"
 date: "2025-09-27"
 tool: "RuangRiung (Flux)"
+image: "https://www.facebook.com/share/p/1BhTw2JZ1W/"
 tags:
   - chibi art
   - punk style


### PR DESCRIPTION
## Summary
- add the Facebook image link to the Chibi Punk prompt frontmatter so the detail page shows it

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d72a69fffc832ebfbed46e88df2250