### PR TITLE
Set seeddream as default image model

### DIFF
--- a/components/Generator.tsx
+++ b/components/Generator.tsx
@@ -34,7 +34,7 @@ export default function Generator() {
     return {
       prompt: initialPrompt,
       negativePrompt: '',
-      model: 'flux',
+      model: 'seeddream',
       cfg_scale: 7,
       width: 1024,
       height: 1792,
@@ -82,10 +82,10 @@ export default function Generator() {
         if (!response.ok) throw new Error(`Gagal mengambil model: ${response.statusText}`);
         const data = await response.json();
         let fetchedModels: string[] = Array.isArray(data) ? data : ['flux', 'turbo'];
-        setModelList([...new Set([...fetchedModels, 'DALL-E 3', 'Leonardo'])]);
+        setModelList([...new Set([...fetchedModels, 'seeddream', 'DALL-E 3', 'Leonardo'])]);
       } catch (error) {
         console.error("Error mengambil model gambar:", error);
-        setModelList(['flux', 'turbo', 'gptimage', 'kontext', 'DALL-E 3', 'Leonardo']);
+        setModelList(['seeddream', 'flux', 'turbo', 'gptimage', 'kontext', 'DALL-E 3', 'Leonardo']);
       }
     };
     fetchImageModels();


### PR DESCRIPTION
## Summary
- set the generator's initial model selection to seeddream so it loads by default
- ensure the model list always includes seeddream when fetching or falling back

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dec7e83760832e831df647e0e421e5