### PR TITLE
Restore Unique Art Name layout and relocate CTA

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -205,13 +205,6 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
             </>
           }
         />
-        <Link
-          href="/UniqueArtName"
-          className="w-full sm:flex-1 inline-flex items-center justify-center gap-2 px-5 py-3 bg-purple-600 text-white font-bold rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset hover:bg-purple-700 transition-colors"
-        >
-          <Sparkles size={18} className="text-yellow-300" />
-          <span>Tema Unik</span>
-        </Link>
       </div>
 
       <div className="w-full max-w-4xl mb-4">
@@ -254,6 +247,16 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
             {isToolsMenuOpen && (
                 <div className="absolute top-full mt-2 w-full bg-gray-700 dark:bg-dark-bg border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl z-10">
                     <ul className="py-2">
+                        <li>
+                            <Link
+                                href="/UniqueArtName"
+                                className="w-full flex items-center gap-3 px-4 py-2 text-gray-100 dark:text-gray-100 hover:bg-purple-700 dark:hover:bg-gray-700 transition-colors"
+                                onClick={() => setIsToolsMenuOpen(false)}
+                            >
+                                <Sparkles size={18} />
+                                <span>Tema Unik</span>
+                            </Link>
+                        </li>
                         <li>
                             <Link
                                 href="/storyteller"


### PR DESCRIPTION
## Summary
- move the Unique Art Name call-to-action into the "Fitur Lainnya" dropdown on the homepage
- restore the Unique Art Name generator header so the theme toggle sits beside the back link

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ded17a17c8832ea8f55f65afc5afff