### PR TITLE
Clarify prompt submission workflow on dedicated page

### DIFF
--- a/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
+++ b/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { CheckCircle2 } from 'lucide-react';
+import PromptSubmissionPageForm, {
+  type PromptSubmissionPageFormResult,
+} from './PromptSubmissionPageForm';
+
+export default function PromptSubmissionPageClient() {
+  const router = useRouter();
+  const [result, setResult] = useState<PromptSubmissionPageFormResult | null>(null);
+
+  const handleCancel = () => {
+    router.push('/kumpulan-prompt');
+  };
+
+  const handleSuccess = (value: PromptSubmissionPageFormResult) => {
+    setResult(value);
+  };
+
+  const handleBackToList = () => {
+    router.push('/kumpulan-prompt');
+  };
+
+  const handleSubmitAnother = () => {
+    setResult(null);
+  };
+
+  if (result) {
+    const { prompt, persisted } = result;
+    const persistenceMessage = persisted
+      ? 'Prompt Anda sudah langsung tampil di halaman kumpulan prompt.'
+      : 'Prompt Anda akan kami tinjau terlebih dahulu sebelum dipublikasikan.';
+
+    return (
+      <div className="mx-auto max-w-3xl px-4 pb-16 sm:px-6 lg:px-8">
+        <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-10 text-center shadow-lg dark:border-emerald-400/30 dark:bg-emerald-950/40">
+          <CheckCircle2 className="mx-auto h-12 w-12 text-emerald-500 dark:text-emerald-300" />
+          <h2 className="mt-4 text-2xl font-semibold text-emerald-900 dark:text-emerald-100">
+            Prompt berhasil dikirim!
+          </h2>
+          <p className="mt-4 text-base text-emerald-900 dark:text-emerald-200">
+            “{prompt.title}” untuk {prompt.tool} telah kami terima. {persistenceMessage}
+          </p>
+          <p className="mt-2 text-sm text-emerald-800 dark:text-emerald-300/80">
+            Format front matter akan otomatis mengikuti standar RuangRiung sehingga prompt Anda siap tampil bersama koleksi lain.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <button
+              type="button"
+              onClick={handleBackToList}
+              className="inline-flex items-center justify-center rounded-2xl bg-emerald-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500"
+            >
+              Lihat Kumpulan Prompt
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmitAnother}
+              className="inline-flex items-center justify-center rounded-2xl border border-emerald-400 px-6 py-3 text-sm font-semibold text-emerald-700 transition hover:border-emerald-500 hover:text-emerald-900 dark:border-emerald-400/60 dark:text-emerald-200 dark:hover:border-emerald-300 dark:hover:text-emerald-100"
+            >
+              Kirim Prompt Lain
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 pb-16 sm:px-6 lg:px-8">
+      <section className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-800/60 dark:bg-slate-900/70 sm:p-8">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+          Cara kerja pengiriman prompt
+        </h2>
+        <ol className="mt-4 space-y-4 text-sm leading-6 text-slate-600 dark:text-slate-300">
+          <li className="flex gap-3">
+            <span className="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-blue-100 font-semibold text-blue-600 dark:bg-blue-400/20 dark:text-blue-200">
+              1
+            </span>
+            <span>
+              Isi seluruh kolom dengan data kontributor, isi prompt, serta lampiran opsional. Form halaman ini memvalidasi CAPTCHA Turnstile agar mencegah spam sebelum permintaan dikirim.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-blue-100 font-semibold text-blue-600 dark:bg-blue-400/20 dark:text-blue-200">
+              2
+            </span>
+            <span>
+              Setelah tombol kirim ditekan, data dikirim ke endpoint <code className="rounded-md bg-slate-100 px-1.5 py-0.5 text-[0.75rem] dark:bg-slate-800">/api/submit-prompt</code> yang menyusun front matter Markdown baru dengan struktur sama persis seperti prompt yang sudah tayang.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-blue-100 font-semibold text-blue-600 dark:bg-blue-400/20 dark:text-blue-200">
+              3
+            </span>
+            <span>
+              Jika moderasi otomatis menyetujui, prompt segera ditambahkan ke katalog dan Anda melihat kartu konfirmasi di halaman ini. Jika perlu peninjauan manual, tim RuangRiung akan memproses sebelum publikasi.
+            </span>
+          </li>
+        </ol>
+        <div className="mt-6 rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200">
+          <p className="font-semibold text-slate-900 dark:text-slate-100">Apa bedanya dengan form submission sebelumnya?</p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>
+              <span className="font-medium">Tampilan halaman penuh.</span> Form ini hadir sebagai halaman mandiri dengan tips, penjelasan alur, dan status sukses on-page. Form lama tetap berupa modal ringan yang muncul dari tombol &ldquo;Kirim Prompt Anda&rdquo;.
+            </li>
+            <li>
+              <span className="font-medium">Fokus kontribusi.</span> Pengguna tetap berada di halaman ini setelah kirim sehingga bisa mengirim prompt lain, sedangkan modal lama langsung menutup dan mengembalikan pengguna ke konteks sebelumnya.
+            </li>
+            <li>
+              <span className="font-medium">Pengalaman berbeda, backend sama.</span> Keduanya menuju endpoint yang sama sehingga hasil front matter identik. Perbedaannya hanya pada pengalaman antarmuka dan dukungan konten panduan.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <div className="mt-8">
+        <PromptSubmissionPageForm onCancel={handleCancel} onSuccess={handleSuccess} />
+      </div>
+    </div>
+  );
+}

--- a/app/kumpulan-prompt/kirim/PromptSubmissionPageForm.tsx
+++ b/app/kumpulan-prompt/kirim/PromptSubmissionPageForm.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import dynamic from 'next/dynamic';
+import type { Prompt } from '@/lib/prompts';
+
+const DynamicTurnstile = dynamic(() => import('@/components/TurnstileWidget'), {
+  ssr: false,
+  loading: () => (
+    <div className="h-[65px] w-[300px] animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700" />
+  ),
+});
+
+const parseTags = (value: string) =>
+  value
+    .split(',')
+    .map(tag => tag.trim())
+    .filter(tag => tag.length > 0);
+
+export interface PromptSubmissionPageFormResult {
+  prompt: Prompt;
+  persisted: boolean;
+}
+
+interface PromptSubmissionPageFormProps {
+  onCancel: () => void;
+  onSuccess: (result: PromptSubmissionPageFormResult) => void;
+}
+
+export default function PromptSubmissionPageForm({ onCancel, onSuccess }: PromptSubmissionPageFormProps) {
+  const [author, setAuthor] = useState('');
+  const [email, setEmail] = useState('');
+  const [title, setTitle] = useState('');
+  const [promptContent, setPromptContent] = useState('');
+  const [tool, setTool] = useState('');
+  const [tags, setTags] = useState('');
+  const [facebook, setFacebook] = useState('');
+  const [link, setLink] = useState('');
+  const [image, setImage] = useState('');
+  const [token, setToken] = useState('');
+  const [captchaError, setCaptchaError] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setAuthor('');
+    setEmail('');
+    setTitle('');
+    setPromptContent('');
+    setTool('');
+    setTags('');
+    setFacebook('');
+    setLink('');
+    setImage('');
+    setToken('');
+    setCaptchaError(false);
+    setSubmitError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!token) {
+      setCaptchaError(true);
+      return;
+    }
+
+    setCaptchaError(false);
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    const payload = {
+      author: author.trim(),
+      email: email.trim(),
+      facebook: facebook.trim(),
+      image: image.trim(),
+      link: link.trim(),
+      title: title.trim(),
+      promptContent: promptContent.trim(),
+      tool: tool.trim(),
+      tags: parseTags(tags),
+    };
+
+    try {
+      const response = await fetch('/api/submit-prompt', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ...payload, token }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data?.message || 'Gagal memproses permintaan.');
+      }
+
+      const prompt: Prompt | undefined = data?.prompt;
+      const persisted: boolean = typeof data?.persisted === 'boolean' ? data.persisted : true;
+
+      if (!prompt) {
+        throw new Error('Server tidak mengembalikan data prompt.');
+      }
+
+      resetForm();
+      onSuccess({ prompt, persisted });
+    } catch (error) {
+      console.error('Prompt submission failed:', error);
+      setSubmitError(
+        error instanceof Error ? error.message : 'Gagal memproses permintaan. Silakan coba lagi.',
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl border border-blue-100 bg-gradient-to-br from-blue-50 via-white to-white p-6 shadow-sm dark:border-blue-400/30 dark:from-slate-900 dark:via-slate-900 dark:to-slate-900 dark:text-slate-100 sm:p-8">
+        <h2 className="text-xl font-semibold text-blue-900 dark:text-blue-200">
+          Tips agar prompt Anda mudah dikurasi
+        </h2>
+        <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-slate-600 dark:text-slate-300">
+          <li>Tuliskan judul yang singkat, jelas, dan menggambarkan hasil akhir prompt.</li>
+          <li>Jelaskan konteks penggunaan prompt secara rinci agar mudah direplikasi.</li>
+          <li>Sertakan referensi visual atau tautan yang mendukung bila tersedia.</li>
+          <li>Pisahkan tag dengan koma untuk memudahkan pencarian dan kategorisasi.</li>
+        </ul>
+      </section>
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-xl backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/80 sm:p-10"
+      >
+        <fieldset className="space-y-6">
+          <legend className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Informasi Kontributor
+          </legend>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div>
+              <label htmlFor="author" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Nama Lengkap
+              </label>
+              <input
+                id="author"
+                type="text"
+                value={author}
+                onChange={event => setAuthor(event.target.value)}
+                required
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+              />
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                Nama ini akan ditampilkan sebagai kontributor prompt.
+              </p>
+            </div>
+            <div>
+              <label htmlFor="email" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Email Aktif
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={event => setEmail(event.target.value)}
+                required
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+              />
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                Kami hanya menggunakan email ini untuk konfirmasi internal.
+              </p>
+            </div>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div>
+              <label htmlFor="facebook" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Facebook / Media Sosial (opsional)
+              </label>
+              <input
+                id="facebook"
+                type="url"
+                value={facebook}
+                onChange={event => setFacebook(event.target.value)}
+                placeholder="https://www.facebook.com/username"
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+              />
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                Tautan ini akan kami tampilkan bila Anda ingin dicantumkan sebagai sumber.
+              </p>
+            </div>
+            <div>
+              <label htmlFor="link" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Referensi Tambahan (opsional)
+              </label>
+              <input
+                id="link"
+                type="url"
+                value={link}
+                onChange={event => setLink(event.target.value)}
+                placeholder="https://contoh.com/inspirasi"
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+              />
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                Sertakan rujukan jika prompt terinspirasi dari sumber tertentu.
+              </p>
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset className="mt-10 space-y-6">
+          <legend className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Detail Prompt
+          </legend>
+          <div>
+            <label htmlFor="title" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              Judul Prompt
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={title}
+              onChange={event => setTitle(event.target.value)}
+              required
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+            />
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              Maksimalkan 70 karakter pertama agar menarik di halaman daftar prompt.
+            </p>
+          </div>
+          <div>
+            <label htmlFor="promptContent" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              Isi Prompt Lengkap
+            </label>
+            <textarea
+              id="promptContent"
+              value={promptContent}
+              onChange={event => setPromptContent(event.target.value)}
+              required
+              rows={8}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+            />
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              Cantumkan instruksi langkah demi langkah atau parameter penting agar hasilnya konsisten.
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-[1.2fr_0.8fr]">
+            <div>
+              <label htmlFor="tool" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Tool / Model AI
+              </label>
+              <input
+                id="tool"
+                type="text"
+                value={tool}
+                onChange={event => setTool(event.target.value)}
+                required
+                placeholder="Contoh: Midjourney v6, Stable Diffusion XL, ChatGPT"
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+              />
+            </div>
+            <div>
+              <label htmlFor="image" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Gambar Pratinjau (opsional)
+              </label>
+              <input
+                id="image"
+                type="url"
+                value={image}
+                onChange={event => setImage(event.target.value)}
+                placeholder="https://images.site/prompt.jpg"
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+              />
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                Gunakan URL gambar beresolusi tinggi (jika ada) untuk mempercantik katalog prompt.
+              </p>
+            </div>
+          </div>
+          <div>
+            <label htmlFor="tags" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              Tag Prompt
+            </label>
+            <input
+              id="tags"
+              type="text"
+              value={tags}
+              onChange={event => setTags(event.target.value)}
+              placeholder="contoh: karakter, sci-fi, produk"
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+            />
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              Pisahkan dengan koma. Tag membantu kami membuat front matter secara otomatis.
+            </p>
+          </div>
+        </fieldset>
+
+        <div className="mt-10 space-y-6">
+          <div className="flex justify-center">
+            <DynamicTurnstile onSuccess={value => setToken(value)} />
+          </div>
+          {captchaError && (
+            <p className="text-center text-sm font-semibold text-red-500">
+              Silakan selesaikan verifikasi keamanan sebelum mengirim.
+            </p>
+          )}
+          {submitError && (
+            <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-950/50 dark:text-red-200">
+              {submitError}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-slate-100"
+          >
+            Batal dan Kembali
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting || !token}
+            className="inline-flex items-center justify-center rounded-2xl bg-blue-600 px-8 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 disabled:cursor-not-allowed disabled:bg-blue-300"
+          >
+            {isSubmitting ? 'Mengirim Prompt...' : 'Kirim Prompt ke RuangRiung'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/kumpulan-prompt/kirim/page.tsx
+++ b/app/kumpulan-prompt/kirim/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import PromptSubmissionPageClient from './PromptSubmissionPageClient';
+
+const PAGE_URL = 'https://ruangriung.my.id/kumpulan-prompt/kirim';
+const SOCIAL_IMAGE_URL = 'https://ruangriung.my.id/og-image/og-image-rr.png';
+
+export const metadata: Metadata = {
+  title: 'Kirim Prompt AI Kreatif Anda - RuangRiung Generator',
+  description:
+    'Bagikan prompt AI terbaik Anda untuk Midjourney, Stable Diffusion, ChatGPT, dan generator kreatif lainnya. Kirim prompt dan bantu komunitas RuangRiung menemukan inspirasi baru.',
+  keywords: [
+    'kirim prompt AI',
+    'submit prompt Midjourney',
+    'unggah prompt Stable Diffusion',
+    'bagikan prompt ChatGPT',
+    'komunitas prompt kreatif',
+    'ruangriung prompt submission',
+  ],
+  alternates: {
+    canonical: PAGE_URL,
+  },
+  openGraph: {
+    title: 'Kirim Prompt AI Kreatif Anda - RuangRiung Generator',
+    description:
+      'Isi formulir untuk mengirim prompt AI Anda dan bantu komunitas RuangRiung mendapatkan inspirasi baru untuk berbagai model AI.',
+    url: PAGE_URL,
+    siteName: 'RuangRiung AI Generator',
+    locale: 'id_ID',
+    type: 'website',
+    images: [
+      {
+        url: SOCIAL_IMAGE_URL,
+        width: 1200,
+        height: 630,
+        alt: 'Formulir pengiriman prompt AI RuangRiung',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Kirim Prompt AI Kreatif Anda - RuangRiung Generator',
+    description:
+      'Kirim prompt AI terbaik Anda ke RuangRiung dan bantu pengguna lain menemukan ide kreatif baru.',
+    images: [SOCIAL_IMAGE_URL],
+  },
+};
+
+export default function PromptSubmissionPage() {
+  return (
+    <div className="bg-gradient-to-b from-sky-50 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-gray-900">
+      <div className="mx-auto max-w-3xl px-4 pt-12 pb-10 sm:px-6 lg:px-8">
+        <Link
+          href="/kumpulan-prompt"
+          className="inline-flex items-center text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Kembali ke Kumpulan Prompt
+        </Link>
+        <h1 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-50 sm:text-4xl">
+          Bagikan Prompt Kreatif Anda
+        </h1>
+        <p className="mt-4 text-lg text-gray-600 dark:text-gray-300">
+          Isi formulir di bawah ini untuk mengirim prompt AI terbaik Anda. Prompt yang berhasil dikirim akan
+          otomatis muncul di halaman kumpulan prompt dengan format front matter yang sama seperti prompt lainnya.
+        </p>
+      </div>
+      <PromptSubmissionPageClient />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an on-page explainer describing how prompt submissions are processed
- highlight key differences between the full-page form and the existing modal submission flow
- wrap the existing form with spacing so the explainer and form remain visually separated

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e509013a98832e9e3b6a3988c2dfae