### PR TITLE
Allow prompt submission page to bypass email flow

### DIFF
--- a/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
+++ b/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
@@ -46,6 +46,38 @@ export default function PromptSubmissionPageClient() {
           <p className="mt-2 text-sm text-emerald-800 dark:text-emerald-300/80">
             Format front matter akan otomatis mengikuti standar RuangRiung sehingga prompt Anda siap tampil bersama koleksi lain.
           </p>
+          <div className="mt-8 text-left">
+            <div className="rounded-2xl border border-emerald-200 bg-white/70 p-6 shadow-inner dark:border-emerald-400/30 dark:bg-emerald-950/30">
+              <p className="text-xs font-semibold uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                Preview prompt yang baru ditambahkan
+              </p>
+              <h3 className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">{prompt.title}</h3>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                Oleh <span className="font-medium text-slate-900 dark:text-white">{prompt.author}</span>
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs font-medium">
+                {prompt.tags.map(tag => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200"
+                  >
+                    #{tag}
+                  </span>
+                ))}
+                {prompt.tags.length === 0 ? (
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-500 dark:bg-slate-800 dark:text-slate-300">
+                    Tidak ada tag
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-4 rounded-2xl border border-dashed border-emerald-200 bg-emerald-50/80 p-4 text-sm leading-relaxed text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-900/40 dark:text-emerald-100">
+                <p className="whitespace-pre-line">{prompt.promptContent}</p>
+              </div>
+              <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+                Slug otomatis: <span className="font-medium text-slate-700 dark:text-slate-200">{prompt.slug}</span>
+              </p>
+            </div>
+          </div>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
             <button
               type="button"

--- a/app/kumpulan-prompt/kirim/PromptSubmissionPageForm.tsx
+++ b/app/kumpulan-prompt/kirim/PromptSubmissionPageForm.tsx
@@ -87,7 +87,7 @@ export default function PromptSubmissionPageForm({ onCancel, onSuccess }: Prompt
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ ...payload, token }),
+        body: JSON.stringify({ ...payload, token, skipEmail: true }),
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary
- allow the dedicated /kumpulan-prompt/kirim form to opt out of email delivery while keeping existing flows unchanged
- surface an on-page preview of the newly submitted prompt so contributors immediately see their content

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e515e7247c832e9f465959953f0f79