### PR TITLE
Handle read-only prompt submissions and add date field

### DIFF
--- a/app/api/submit-prompt/route.ts
+++ b/app/api/submit-prompt/route.ts
@@ -90,6 +90,7 @@ export async function POST(request: Request) {
     const tool = sanitizeString(body.tool);
     const tags = ensureStringArray(body.tags);
     const token = sanitizeString(body.token);
+    const date = sanitizeOptionalString(body.date);
 
     if (!author || !email || !title || !promptContent || !tool || !token) {
       return NextResponse.json(
@@ -138,6 +139,7 @@ export async function POST(request: Request) {
       promptContent,
       tool,
       tags,
+      date,
     });
 
     if (!skipEmail) {
@@ -163,6 +165,7 @@ export async function POST(request: Request) {
 
       const safeTags = tags.map(tag => escapeHtml(tag));
       const formattedTags = safeTags.length > 0 ? safeTags.join(', ') : '-';
+      const formattedDate = formatOptionalValue(date);
       const mailOptions = {
         from: senderAddress,
         to: recipientAddress,
@@ -174,6 +177,7 @@ export async function POST(request: Request) {
           <p><strong>Link Facebook:</strong> ${formatOptionalValue(facebook)}</p>
           <p><strong>Link:</strong> ${formatOptionalValue(link)}</p>
           <p><strong>Link Gambar:</strong> ${formatOptionalValue(image)}</p>
+          <p><strong>Tanggal Publikasi:</strong> ${formattedDate}</p>
           <p><strong>Judul Prompt:</strong> ${escapeHtml(title)}</p>
           <p><strong>Tool:</strong> ${escapeHtml(tool)}</p>
           <p><strong>Tags:</strong> ${formattedTags}</p>

--- a/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
+++ b/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
@@ -31,7 +31,7 @@ export default function PromptSubmissionPageClient() {
     const { prompt, persisted } = result;
     const persistenceMessage = persisted
       ? 'Prompt Anda sudah langsung tampil di halaman kumpulan prompt.'
-      : 'Prompt Anda akan kami tinjau terlebih dahulu sebelum dipublikasikan.';
+      : 'Prompt Anda sudah langsung tampil di katalog dan akan kami simpan permanen setelah peninjauan.';
 
     return (
       <div className="mx-auto max-w-3xl px-4 pb-16 sm:px-6 lg:px-8">
@@ -54,6 +54,10 @@ export default function PromptSubmissionPageClient() {
               <h3 className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">{prompt.title}</h3>
               <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
                 Oleh <span className="font-medium text-slate-900 dark:text-white">{prompt.author}</span>
+              </p>
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Tanggal publikasi:{' '}
+                <span className="font-medium text-slate-700 dark:text-slate-200">{prompt.date}</span>
               </p>
               <div className="mt-3 flex flex-wrap gap-2 text-xs font-medium">
                 {prompt.tags.map(tag => (

--- a/app/kumpulan-prompt/kirim/PromptSubmissionPageForm.tsx
+++ b/app/kumpulan-prompt/kirim/PromptSubmissionPageForm.tsx
@@ -37,6 +37,7 @@ export default function PromptSubmissionPageForm({ onCancel, onSuccess }: Prompt
   const [facebook, setFacebook] = useState('');
   const [link, setLink] = useState('');
   const [image, setImage] = useState('');
+  const [date, setDate] = useState('');
   const [token, setToken] = useState('');
   const [captchaError, setCaptchaError] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -52,6 +53,7 @@ export default function PromptSubmissionPageForm({ onCancel, onSuccess }: Prompt
     setFacebook('');
     setLink('');
     setImage('');
+    setDate('');
     setToken('');
     setCaptchaError(false);
     setSubmitError(null);
@@ -69,6 +71,7 @@ export default function PromptSubmissionPageForm({ onCancel, onSuccess }: Prompt
     setIsSubmitting(true);
     setSubmitError(null);
 
+    const normalizedDate = date.trim();
     const payload = {
       author: author.trim(),
       email: email.trim(),
@@ -79,6 +82,7 @@ export default function PromptSubmissionPageForm({ onCancel, onSuccess }: Prompt
       promptContent: promptContent.trim(),
       tool: tool.trim(),
       tags: parseTags(tags),
+      date: normalizedDate || undefined,
     };
 
     try {
@@ -274,6 +278,21 @@ export default function PromptSubmissionPageForm({ onCancel, onSuccess }: Prompt
                 Gunakan URL gambar beresolusi tinggi (jika ada) untuk mempercantik katalog prompt.
               </p>
             </div>
+          </div>
+          <div>
+            <label htmlFor="date" className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              Tanggal Publikasi (opsional)
+            </label>
+            <input
+              id="date"
+              type="date"
+              value={date}
+              onChange={event => setDate(event.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
+            />
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              Kosongkan untuk menggunakan tanggal hari ini secara otomatis.
+            </p>
           </div>
           <div>
             <label htmlFor="tags" className="text-sm font-medium text-slate-700 dark:text-slate-200">

--- a/components/PromptSubmissionForm.tsx
+++ b/components/PromptSubmissionForm.tsx
@@ -41,6 +41,7 @@ export default function PromptSubmissionForm({
   const [facebook, setFacebook] = useState('');
   const [link, setLink] = useState('');
   const [image, setImage] = useState('');
+  const [date, setDate] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<'success' | 'error' | null>(null);
   const [feedbackMessage, setFeedbackMessage] = useState('');
@@ -66,6 +67,7 @@ export default function PromptSubmissionForm({
     setFacebook(prompt?.facebook ?? '');
     setLink(prompt?.link ?? '');
     setImage(prompt?.image ?? '');
+    setDate(prompt?.date ?? '');
     setSubmitStatus(null);
     setFeedbackMessage('');
     setCaptchaError(false);
@@ -103,6 +105,7 @@ export default function PromptSubmissionForm({
     setSubmitStatus(null);
     setFeedbackMessage('');
 
+    const normalizedDate = date.trim();
     const payload = {
       author: author.trim(),
       email: email.trim(),
@@ -113,6 +116,7 @@ export default function PromptSubmissionForm({
       promptContent: promptContent.trim(),
       tool: tool.trim(),
       tags: parseTags(tags),
+      date: normalizedDate || undefined,
     };
 
     try {
@@ -120,7 +124,7 @@ export default function PromptSubmissionForm({
       const method = isEditMode ? 'PATCH' : 'POST';
       const body = {
         ...payload,
-        ...(isEditMode ? { date: initialPrompt?.date } : { token }),
+        ...(isEditMode ? {} : { token }),
       };
 
       const headers: HeadersInit = {
@@ -161,6 +165,7 @@ export default function PromptSubmissionForm({
         setFacebook(prompt.facebook ?? '');
         setLink(prompt.link ?? '');
         setImage(prompt.image ?? '');
+        setDate(prompt.date ?? '');
       } else {
         setAuthor('');
         setEmail('');
@@ -171,6 +176,7 @@ export default function PromptSubmissionForm({
         setFacebook('');
         setLink('');
         setImage('');
+        setDate('');
         setToken('');
       }
 
@@ -179,7 +185,7 @@ export default function PromptSubmissionForm({
         ? 'Prompt berhasil diperbarui dan perubahan langsung ditayangkan.'
         : persisted
             ? 'Prompt berhasil dikirim dan langsung dipublikasikan.'
-            : 'Prompt berhasil dikirim. Tim kami akan meninjau dan memublikasikannya secara manual.';
+            : 'Prompt berhasil dikirim dan langsung ditampilkan di katalog dengan penyimpanan sementara.';
       setFeedbackMessage(successMessage);
 
       onSuccess?.(prompt);
@@ -281,6 +287,21 @@ export default function PromptSubmissionForm({
               required
               className="w-full p-2 border rounded mb-4 dark:bg-gray-700"
             />
+            <div className="mb-4">
+              <label htmlFor="prompt-date" className="block text-sm font-medium text-gray-700 dark:text-gray-200">
+                Tanggal Publikasi (opsional)
+              </label>
+              <input
+                id="prompt-date"
+                type="date"
+                value={date}
+                onChange={e => setDate(e.target.value)}
+                className="mt-2 w-full p-2 border rounded dark:bg-gray-700"
+              />
+              <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                Kosongkan untuk menggunakan tanggal hari ini secara otomatis.
+              </p>
+            </div>
             <input
               type="text"
               placeholder="Tags (pisahkan dengan koma)"


### PR DESCRIPTION
## Summary
- cache transient prompts in memory so new submissions appear immediately even when the filesystem is read-only
- accept an optional publish date in the submit-prompt API and propagate it to moderation emails and prompt metadata
- surface a publish date input in both submission UIs and update the success messaging to reflect immediate catalogue visibility

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e51989b220832e975e626079de7b94