### PR TITLE
Add dedicated prompt submission page

### DIFF
--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -304,6 +304,16 @@ export default function PromptClient({ prompts }: PromptClientProps) {
           className="mt-6 px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg"
           onSuccess={handlePromptCreated}
         />
+        <p className="mt-4 text-sm text-gray-600 dark:text-gray-400">
+          Ingin pengalaman pengiriman penuh?{' '}
+          <Link
+            href="/kumpulan-prompt/kirim"
+            className="font-semibold text-blue-600 hover:underline dark:text-blue-400"
+          >
+            Buka halaman kirim prompt
+          </Link>
+          .
+        </p>
       </div>
 
       <div className="mb-10 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900">

--- a/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
+++ b/app/kumpulan-prompt/kirim/PromptSubmissionPageClient.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useCallback } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Sparkles } from 'lucide-react';
+import PromptSubmissionForm from '@/components/PromptSubmissionForm';
+import type { Prompt } from '@/lib/prompts';
+
+export default function PromptSubmissionPageClient() {
+  const router = useRouter();
+
+  const handleSuccess = useCallback(
+    (prompt: Prompt) => {
+      router.prefetch('/kumpulan-prompt');
+      router.prefetch(`/kumpulan-prompt/${prompt.slug}`);
+    },
+    [router],
+  );
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-12 dark:bg-gray-900">
+      <div className="container mx-auto px-4">
+        <div className="mb-8 flex justify-center">
+          <Link
+            href="/kumpulan-prompt"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-light-bg px-4 py-2 font-semibold text-gray-700 shadow-neumorphic-button transition hover:-translate-y-0.5 hover:shadow-neumorphic-button-hover dark:bg-dark-bg dark:text-gray-200 dark:shadow-dark-neumorphic-button"
+          >
+            <ArrowLeft size={18} />
+            <span>Kembali ke Kumpulan Prompt</span>
+          </Link>
+        </div>
+
+        <div className="mx-auto max-w-3xl rounded-3xl bg-white p-6 shadow-xl dark:bg-gray-800 sm:p-10">
+          <div className="mb-8 text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-blue-500 text-white shadow-lg">
+              <Sparkles className="h-8 w-8" />
+            </div>
+            <h1 className="text-3xl font-extrabold text-gray-900 dark:text-white sm:text-4xl">
+              Bagikan Prompt Kreatifmu
+            </h1>
+            <p className="mt-3 text-base text-gray-600 dark:text-gray-300 sm:text-lg">
+              Isi formulir di bawah ini untuk mempublikasikan prompt Anda di RuangRiung. Prompt yang berhasil dikirim akan langsung tampil di katalog dan mendapatkan halaman detail tersendiri.
+            </p>
+          </div>
+
+          <PromptSubmissionForm isOpen variant="page" onSuccess={handleSuccess} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/kumpulan-prompt/kirim/page.tsx
+++ b/app/kumpulan-prompt/kirim/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import PromptSubmissionPageClient from './PromptSubmissionPageClient';
+
+const PAGE_URL = 'https://ruangriung.my.id/kumpulan-prompt/kirim';
+const SOCIAL_IMAGE_URL = 'https://ruangriung.my.id/og-image/og-image-rr.png';
+
+export const metadata: Metadata = {
+  title: 'Kirim Prompt AI Kreatif - RuangRiung Generator',
+  description:
+    'Bagikan prompt AI buatanmu ke komunitas RuangRiung. Prompt yang berhasil dikirim akan tampil di katalog dan mendapatkan halaman detail secara otomatis.',
+  alternates: {
+    canonical: PAGE_URL,
+  },
+  openGraph: {
+    title: 'Kirim Prompt AI Kreatif - RuangRiung Generator',
+    description:
+      'Isi formulir kirim prompt dan jadikan inspirasimu tersedia bagi kreator lainnya. Prompt yang disetujui langsung muncul di katalog RuangRiung.',
+    url: PAGE_URL,
+    siteName: 'RuangRiung AI Generator',
+    locale: 'id_ID',
+    type: 'website',
+    images: [
+      {
+        url: SOCIAL_IMAGE_URL,
+        width: 1200,
+        height: 630,
+        alt: 'Kirim prompt AI kreatif melalui RuangRiung',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Kirim Prompt AI Kreatif - RuangRiung Generator',
+    description:
+      'Kirim prompt AI terbaikmu dan buat halaman detail otomatis untuk dibagikan kepada komunitas.',
+    images: [SOCIAL_IMAGE_URL],
+  },
+};
+
+export default function PromptSubmissionPage() {
+  return <PromptSubmissionPageClient />;
+}


### PR DESCRIPTION
## Summary
- create a standalone `/kumpulan-prompt/kirim` page for submitting prompts with tailored layout and metadata
- update the reusable prompt submission form to support a page variant with success links to the prompt catalogue and detail view
- surface a link from the prompt catalogue to the dedicated submission page for easier discovery

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68e73cc8c5e8832eb33374532cef3584