### PR TITLE
feat: redesign facebook pro insight dashboard

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -265,7 +265,7 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
                                 onClick={() => setIsToolsMenuOpen(false)}
                             >
                                 <Megaphone size={18} />
-                                <span>InsightRanker FB Pro</span>
+                                <span>Facebook Pro Insight Hub</span>
                             </Link>
                         </li>
                         <li>

--- a/app/facebook-pro-insight/page.tsx
+++ b/app/facebook-pro-insight/page.tsx
@@ -1,34 +1,36 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
-import { ArrowLeft, FacebookIcon } from 'lucide-react';
 import dynamic from 'next/dynamic';
 
-const FacebookProAnalyzerClient = dynamic(() => import('./FacebookProAnalyzerClient'), {
+const FacebookProInsightClient = dynamic(() => import('./FacebookProAnalyzerClient'), {
   ssr: false,
   loading: () => (
-    <div className="mt-10 rounded-2xl bg-light-bg p-6 shadow-neumorphic-card dark:bg-dark-bg dark:shadow-dark-neumorphic-card">
-      <p className="text-center text-lg font-semibold text-gray-700 dark:text-gray-200">
-        Menyiapkan kanvas analitik InsightRanker...
+    <div className="mx-auto mt-16 max-w-4xl rounded-3xl bg-light-bg/80 p-6 text-center shadow-neumorphic-card backdrop-blur dark:bg-dark-bg/60 dark:shadow-dark-neumorphic-card">
+      <p className="text-lg font-semibold text-gray-700 dark:text-gray-200">
+        Menginisialisasi pusat analitik konten profesional...
+      </p>
+      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+        Memuat model AI dan menyiapkan tampilan dashboard.
       </p>
     </div>
   ),
 });
 
 export const metadata: Metadata = {
-  title: 'InsightRanker untuk Facebook Pro - Analitik Kualitas Konten',
+  title: 'Facebook Pro Insight Hub - Analisis Konten Profesional',
   description:
-    'Gunakan InsightRanker untuk menilai kreativitas, relevansi, dan daya tarik emosional konten profesional Facebook Anda dengan analitik AI multimodal.',
+    'Optimalkan performa konten Facebook profesional Anda dengan analisis AI mendalam. Dapatkan rekomendasi monetisasi, kesesuaian audiens Indonesia, dan strategi teknis terkini.',
   keywords: [
-    'InsightRanker',
     'analisis konten Facebook',
-    'analisis AI multimodal',
-    'evaluasi konten profesional',
-    'engagement predictor',
+    'facebook profesional',
+    'pollinations ai',
+    'strategi monetisasi facebook',
+    'analisis audiens Indonesia',
+    'dashboard insight facebook',
   ],
   openGraph: {
-    title: 'InsightRanker — Mesin Pengendus Kualitas Konten Facebook Pro',
+    title: 'Facebook Pro Insight Hub - Analisis Konten Profesional',
     description:
-      'Dashboard analitik futuristik untuk membaca kreativitas, relevansi, dan daya tarik emosional konten Facebook profesional.',
+      'Dashboard AI terintegrasi untuk mengevaluasi kualitas konten, monetisasi, dan kesesuaian audiens Facebook di pasar Indonesia.',
     url: 'https://ruangriung.my.id/facebook-pro-insight',
     siteName: 'RuangRiung AI Generator',
     images: [
@@ -36,7 +38,7 @@ export const metadata: Metadata = {
         url: 'https://www.ruangriung.my.id/assets/ruangriung.png',
         width: 1200,
         height: 630,
-        alt: 'InsightRanker Dashboard',
+        alt: 'RuangRiung Facebook Pro Insight Hub',
       },
     ],
     locale: 'id_ID',
@@ -44,43 +46,13 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'InsightRanker — Mesin Pengendus Kualitas Konten',
+    title: 'Facebook Pro Insight Hub - Analisis Konten Profesional',
     description:
-      'Analisis mendalam konten Facebook profesional dengan dukungan model AI multimodal yang dinamis.',
+      'Gunakan AI Pollinations untuk menilai konten Facebook profesional Anda dan dapatkan rekomendasi berbasis data.',
     images: ['https://www.ruangriung.my.id/assets/ruangriung.png'],
   },
 };
 
 export default function FacebookProInsightPage() {
-  return (
-    <div className="container mx-auto px-4 py-10 md:px-8 lg:px-12">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 rounded-xl bg-light-bg px-4 py-2 text-sm font-semibold text-gray-700 shadow-neumorphic-button transition-colors hover:text-purple-600 dark:bg-dark-bg dark:text-gray-200 dark:shadow-dark-neumorphic-button"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Kembali ke Beranda
-        </Link>
-        <div className="inline-flex items-center gap-2 rounded-full bg-blue-600/10 px-4 py-2 text-sm font-semibold text-blue-700 dark:bg-blue-400/10 dark:text-blue-200">
-          <FacebookIcon className="h-4 w-4" />
-          Mode Profesional Facebook
-        </div>
-      </div>
-
-      <header className="mt-10 space-y-4 text-center">
-        <p className="text-sm font-medium uppercase tracking-widest text-purple-500">InsightRanker</p>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 md:text-5xl">
-          Mesin Pengendus Kualitas Konten Facebook Pro
-        </h1>
-        <p className="mx-auto max-w-3xl text-base text-gray-600 dark:text-gray-300 md:text-lg">
-          Analisis menyeluruh terhadap kreativitas, relevansi, daya tarik emosional, dan keaslian konten profesional Facebook.
-          InsightRanker memanfaatkan mesin analitik AI multimodal untuk mengaktifkan heuristik visual, pemahaman semantik, dan
-          prediksi engagement secara real-time.
-        </p>
-      </header>
-
-      <FacebookProAnalyzerClient />
-    </div>
-  );
+  return <FacebookProInsightClient />;
 }


### PR DESCRIPTION
## Summary
- rebuild the Facebook Pro Insight client with dynamic Pollinations model loading, debounced analysis workflow, neumorphic dashboard UI, and export/share utilities
- refresh the Facebook Pro Insight metadata for the revamped experience
- update the home page shortcut label to reflect the new Facebook Pro Insight Hub name

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ee81818558832e9b81e793cc5402b6