### PR TITLE
Add weird fusion art prompt and default submission date

### DIFF
--- a/components/PromptSubmissionForm.tsx
+++ b/components/PromptSubmissionForm.tsx
@@ -123,6 +123,8 @@ export default function PromptSubmissionForm({
     setFeedbackMessage('');
 
     const normalizedDate = date.trim();
+    const todayDate = new Date().toISOString().split('T')[0];
+    const resolvedDate = normalizedDate || todayDate;
     const payload = {
       author: author.trim(),
       email: email.trim(),
@@ -133,7 +135,7 @@ export default function PromptSubmissionForm({
       promptContent: promptContent.trim(),
       tool: tool.trim(),
       tags: parseTags(tags),
-      date: normalizedDate || undefined,
+      date: resolvedDate,
     };
 
     try {

--- a/content/prompts/prompt-199.md
+++ b/content/prompts/prompt-199.md
@@ -1,0 +1,26 @@
+---
+id: "199"
+slug: "weird-fusion-art-featuring-a-mysterious-purple-woman"
+title: "Weird Fusion Art featuring a mysterious purple woman"
+author: "Ekin Liu"
+date: "2025-10-16"
+tool: "Imagen 4, Gemini, flux"
+tags:
+  - weird-fusion-art
+  - purple-surrealism
+  - ethereal
+  - fusion-organic-mechanical
+  - cinematic-lighting
+---
+
+A surreal masterpiece of Weird Fusion Art featuring a mysterious purple woman — her skin softly glowing in lilac tones, eyes reflecting galaxies.
+
+💜 Her hair flows like liquid amethyst, merging with metallic wires and floral crystal fragments that shimmer with delicate highlights.
+
+🌿 The background blends organic forms with mechanical shapes — vines intertwined with chrome tubes, soft petals morphing into fractal geometry.
+
+⚖️ The composition feels 30% intricate yet balanced, combining elegance, complexity, and surreal beauty.
+
+🎨 Gentle gradients of violet, silver, and magenta harmonize in ethereal lighting, evoking mystery, sophistication, and dreamlike allure.
+
+Style keywords: weird fusion art, elegant surrealism, purple tones, semi-complex composition (30%), fusion of organic and mechanical, ethereal glow, elegant, artistic complexity, dreamy lighting, high detail, cinematic lighting, 8K ultra realistic, masterpiece.


### PR DESCRIPTION
## Summary
- add a new prompt entry for "Weird Fusion Art featuring a mysterious purple woman"
- ensure the prompt submission form defaults the publication date to today when the field is left blank

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68efe4bfc374832e8d15b7ea9bc8a4c8