### PR TITLE
Add build app prompt collection section

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -19,6 +19,8 @@ import {
   ArrowRight,
   HelpCircle,
   RefreshCw,
+  Image as ImageIcon,
+  AppWindow,
 } from 'lucide-react';
 import Tabs from '../components/Tabs';
 import AuthButton from '@/components/AuthButton';
@@ -44,7 +46,9 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
   const [showInstallButton, setShowInstallButton] = useState(false);
   const [showBanner, setShowBanner] = useState(true);
   const [isToolsMenuOpen, setIsToolsMenuOpen] = useState(false);
+  const [isPromptMenuOpen, setIsPromptMenuOpen] = useState(false);
   const toolsMenuRef = useRef<HTMLDivElement>(null);
+  const promptMenuRef = useRef<HTMLDivElement>(null);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
 
   // Efek untuk PWA Install Prompt
@@ -73,6 +77,8 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setIsHelpOpen(false);
+        setIsToolsMenuOpen(false);
+        setIsPromptMenuOpen(false);
       }
     };
 
@@ -85,9 +91,15 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
   // Efek untuk menutup dropdown menu saat klik di luar area
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-        if (toolsMenuRef.current && !toolsMenuRef.current.contains(event.target as Node)) {
-            setIsToolsMenuOpen(false);
-        }
+      const targetNode = event.target as Node;
+
+      if (toolsMenuRef.current && !toolsMenuRef.current.contains(targetNode)) {
+        setIsToolsMenuOpen(false);
+      }
+
+      if (promptMenuRef.current && !promptMenuRef.current.contains(targetNode)) {
+        setIsPromptMenuOpen(false);
+      }
     };
 
     document.addEventListener('mousedown', handleClickOutside);
@@ -160,13 +172,52 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
       </header>
 
       <div className="w-full max-w-4xl mb-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-        <Link
-          href="/kumpulan-prompt"
-          className="flex items-center justify-center text-center gap-2 px-4 py-3 bg-light-bg dark:bg-dark-bg text-gray-700 dark:text-gray-300 font-semibold text-sm rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all"
-        >
-          <LayoutGrid size={18} />
-          <span>Prompt AI</span>
-        </Link>
+        <div className="relative" ref={promptMenuRef}>
+          <button
+            type="button"
+            onClick={() => setIsPromptMenuOpen(current => !current)}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-light-bg px-4 py-3 text-center text-sm font-semibold text-gray-700 shadow-neumorphic-button transition-all hover:text-purple-600 active:shadow-neumorphic-inset dark:bg-dark-bg dark:text-gray-300 dark:shadow-dark-neumorphic-button dark:hover:text-purple-300 dark:active:shadow-dark-neumorphic-inset"
+          >
+            <LayoutGrid size={18} />
+            <span>Prompt AI</span>
+            <ChevronDown
+              size={16}
+              className={`transition-transform duration-200 ${isPromptMenuOpen ? 'rotate-180' : ''}`}
+            />
+          </button>
+          {isPromptMenuOpen && (
+            <div className="absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900">
+              <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+                <li>
+                  <Link
+                    href="/kumpulan-prompt"
+                    onClick={() => setIsPromptMenuOpen(false)}
+                    className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-purple-50 hover:text-purple-700 focus:bg-purple-50 focus:text-purple-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-purple-200"
+                  >
+                    <ImageIcon className="h-4 w-4" />
+                    <div className="flex flex-col text-left">
+                      <span className="font-semibold">Prompt Gambar</span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">Koleksi prompt visual dan kreatif siap pakai.</span>
+                    </div>
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/kumpulan-prompt/build-app"
+                    onClick={() => setIsPromptMenuOpen(false)}
+                    className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-purple-50 hover:text-purple-700 focus:bg-purple-50 focus:text-purple-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-purple-200"
+                  >
+                    <AppWindow className="h-4 w-4" />
+                    <div className="flex flex-col text-left">
+                      <span className="font-semibold">Prompt App &amp; Website</span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">Blueprint untuk membangun aplikasi, dashboard, dan produk digital.</span>
+                    </div>
+                  </Link>
+                </li>
+              </ul>
+            </div>
+          )}
+        </div>
         <Link href="/artikel" className="flex items-center justify-center text-center gap-2 px-4 py-3 bg-light-bg dark:bg-dark-bg text-gray-700 dark:text-gray-300 font-semibold text-sm rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all">
           <Rss size={18} />
           <span>Artikel</span>

--- a/app/kumpulan-prompt/PromptClient.tsx
+++ b/app/kumpulan-prompt/PromptClient.tsx
@@ -41,9 +41,23 @@ const highlightMatches = (text: string, term: string) => {
 
 interface PromptClientProps {
   prompts: Prompt[];
+  title?: string;
+  description?: string;
+  backHref?: string;
+  backLabel?: string;
+  basePath?: string;
+  showSubmissionTrigger?: boolean;
 }
 
-export default function PromptClient({ prompts }: PromptClientProps) {
+export default function PromptClient({
+  prompts,
+  title,
+  description,
+  backHref,
+  backLabel,
+  basePath,
+  showSubmissionTrigger = true,
+}: PromptClientProps) {
   const [promptList, setPromptList] = useState(() => sortPrompts(prompts));
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState('');
@@ -53,6 +67,12 @@ export default function PromptClient({ prompts }: PromptClientProps) {
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const promptListRef = useRef<HTMLDivElement | null>(null);
   const hasInteractedWithPaginationRef = useRef(false);
+  const effectiveTitle = title ?? 'Kumpulan Prompt';
+  const effectiveDescription = description ??
+    'Jelajahi, gunakan, dan bagikan prompt kreatif untuk berbagai model AI.';
+  const effectiveBackHref = backHref ?? '/';
+  const effectiveBackLabel = backLabel ?? 'Kembali ke Beranda';
+  const effectiveBasePath = basePath ?? '/kumpulan-prompt';
   const topAdSlot = PROMPT_TOP_AD_SLOT;
   const bottomAdSlot = PROMPT_BOTTOM_AD_SLOT;
 
@@ -290,20 +310,22 @@ export default function PromptClient({ prompts }: PromptClientProps) {
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8 flex justify-center">
         <Link
-          href="/"
+          href={effectiveBackHref}
           className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-light-bg dark:bg-dark-bg text-gray-700 dark:text-gray-300 font-bold rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all"
         >
           <ArrowLeft size={18} />
-          <span>Kembali ke Beranda</span>
+          <span>{effectiveBackLabel}</span>
         </Link>
       </div>
       <div className="text-center mb-12">
-        <h1 className="text-4xl md:text-5xl font-extrabold mb-4 text-gray-900 dark:text-white">Kumpulan Prompt</h1>
-        <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">Jelajahi, gunakan, dan bagikan prompt kreatif untuk berbagai model AI.</p>
-        <PromptSubmissionTrigger
-          className="mt-6 px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg"
-          onSuccess={handlePromptCreated}
-        />
+        <h1 className="text-4xl md:text-5xl font-extrabold mb-4 text-gray-900 dark:text-white">{effectiveTitle}</h1>
+        <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">{effectiveDescription}</p>
+        {showSubmissionTrigger && (
+          <PromptSubmissionTrigger
+            className="mt-6 px-8 py-3 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-lg"
+            onSuccess={handlePromptCreated}
+          />
+        )}
       </div>
 
       <div className="mb-10 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900">
@@ -425,7 +447,7 @@ export default function PromptClient({ prompts }: PromptClientProps) {
             key={prompt.id}
             className="flex h-full flex-col rounded-lg border border-gray-200 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-xl dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-gray-700"
           >
-            <Link href={`/kumpulan-prompt/${prompt.slug}`} className="flex-1">
+            <Link href={`${effectiveBasePath}/${prompt.slug}`} className="flex-1">
               <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
                 {highlightMatches(prompt.title, searchTerm)}
               </h5>
@@ -543,7 +565,7 @@ export default function PromptClient({ prompts }: PromptClientProps) {
                 {featuredPrompts.map(prompt => (
                   <Link
                     key={prompt.id}
-                    href={`/kumpulan-prompt/${prompt.slug}`}
+                    href={`${effectiveBasePath}/${prompt.slug}`}
                     className="group flex h-full flex-col justify-between rounded-xl border border-gray-100 bg-gray-50 p-4 transition hover:border-blue-200 hover:bg-white hover:shadow-md dark:border-gray-800 dark:bg-gray-800/60 dark:hover:border-blue-700 dark:hover:bg-gray-800"
                   >
                     <div>

--- a/app/kumpulan-prompt/[slug]/PromptDetailClient.tsx
+++ b/app/kumpulan-prompt/[slug]/PromptDetailClient.tsx
@@ -16,9 +16,22 @@ const sortPrompts = (items: Prompt[]) =>
 interface PromptDetailClientProps {
   prompt: Prompt;
   prompts: Prompt[];
+  collectionHref?: string;
+  collectionLabel?: string;
+  detailBasePath?: string;
+  homeHref?: string;
+  homeLabel?: string;
 }
 
-export default function PromptDetailClient({ prompt, prompts }: PromptDetailClientProps) {
+export default function PromptDetailClient({
+  prompt,
+  prompts,
+  collectionHref = '/kumpulan-prompt',
+  collectionLabel = 'Kembali ke Kumpulan Prompt',
+  detailBasePath = '/kumpulan-prompt',
+  homeHref = '/',
+  homeLabel = 'Kembali ke Beranda',
+}: PromptDetailClientProps) {
   const currentPrompt = prompt;
   const [promptCollection, setPromptCollection] = useState(() => sortPrompts(prompts));
   const [shareFeedback, setShareFeedback] = useState<'idle' | 'success' | 'error'>('idle');
@@ -101,8 +114,8 @@ export default function PromptDetailClient({ prompt, prompts }: PromptDetailClie
   const buildCollectionLink = useCallback((type: 'tag' | 'tool', value: string) => {
     const params = new URLSearchParams();
     params.set(type, value);
-    return `/kumpulan-prompt?${params.toString()}`;
-  }, []);
+    return `${collectionHref}?${params.toString()}`;
+  }, [collectionHref]);
 
   const hasRecommendations =
     featuredPrompts.length > 0 || recommendedTags.length > 0 || recommendedTools.length > 0;
@@ -164,18 +177,18 @@ export default function PromptDetailClient({ prompt, prompts }: PromptDetailClie
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8 flex justify-center">
         <Link
-          href="/kumpulan-prompt"
+          href={collectionHref}
           className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-light-bg dark:bg-dark-bg text-gray-700 dark:text-gray-300 font-bold rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all"
         >
           <ArrowLeft size={18} />
-          <span>Kembali ke Kumpulan Prompt</span>
+          <span>{collectionLabel}</span>
         </Link>
         <Link
-          href="/"
+          href={homeHref}
           className="ml-4 inline-flex items-center justify-center gap-2 px-4 py-2 bg-light-bg dark:bg-dark-bg text-gray-700 dark:text-gray-300 font-bold rounded-lg shadow-neumorphic-button dark:shadow-dark-neumorphic-button active:shadow-neumorphic-inset dark:active:shadow-dark-neumorphic-inset transition-all"
         >
           <ArrowLeft size={18} />
-          <span>Kembali ke Beranda</span>
+          <span>{homeLabel}</span>
         </Link>
       </div>
       <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
@@ -291,7 +304,7 @@ export default function PromptDetailClient({ prompt, prompts }: PromptDetailClie
               {relatedPrompts.map(relatedPrompt => (
                 <Link
                   key={relatedPrompt.slug}
-                  href={`/kumpulan-prompt/${relatedPrompt.slug}`}
+                  href={`${detailBasePath}/${relatedPrompt.slug}`}
                   className="block h-full"
                 >
                   <div className="h-full p-5 bg-gray-50 border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300 dark:bg-gray-900 dark:border-gray-700">
@@ -403,7 +416,7 @@ export default function PromptDetailClient({ prompt, prompts }: PromptDetailClie
                     </p>
                   </div>
                   <Link
-                    href="/kumpulan-prompt"
+                    href={collectionHref}
                     className="inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500/60 dark:text-blue-400"
                   >
                     Lihat semua prompt
@@ -413,7 +426,7 @@ export default function PromptDetailClient({ prompt, prompts }: PromptDetailClie
                   {featuredPrompts.map(featured => (
                     <Link
                       key={featured.slug}
-                      href={`/kumpulan-prompt/${featured.slug}`}
+                      href={`${detailBasePath}/${featured.slug}`}
                       className="group flex h-full flex-col justify-between rounded-xl border border-gray-100 bg-gray-50 p-4 transition hover:border-blue-200 hover:bg-white hover:shadow-md dark:border-gray-800 dark:bg-gray-800/60 dark:hover:border-blue-700 dark:hover:bg-gray-800"
                     >
                       <div>

--- a/app/kumpulan-prompt/build-app/BuildAppPageClient.tsx
+++ b/app/kumpulan-prompt/build-app/BuildAppPageClient.tsx
@@ -16,7 +16,7 @@ import { BUILD_APP_EVENT_CATEGORY, trackAnalyticsEvent } from '@/lib/analytics';
 
 interface BuildAppPageClientProps {
   prompts: Prompt[];
-  articleSlug: string;
+  featuredPromptSlug: string;
 }
 
 const sortByRecency = (items: Prompt[]) =>
@@ -26,7 +26,7 @@ const sortByRecency = (items: Prompt[]) =>
 
 export default function BuildAppPageClient({
   prompts: initialPrompts,
-  articleSlug,
+  featuredPromptSlug,
 }: BuildAppPageClientProps) {
   const [prompts, setPrompts] = useState(() => sortByRecency(initialPrompts));
   const [hasTrackedFormFocus, setHasTrackedFormFocus] = useState(false);
@@ -42,12 +42,12 @@ export default function BuildAppPageClient({
     });
   }, []);
 
-  const handleArticleClick = useCallback(() => {
-    trackAnalyticsEvent('click_build_app_article', {
+  const handleFeaturedPromptClick = useCallback(() => {
+    trackAnalyticsEvent('click_build_app_featured_prompt', {
       event_category: BUILD_APP_EVENT_CATEGORY,
-      article_slug: articleSlug,
+      prompt_slug: featuredPromptSlug,
     });
-  }, [articleSlug]);
+  }, [featuredPromptSlug]);
 
   const handlePromptCreated = useCallback(
     (prompt: Prompt) => {
@@ -145,11 +145,11 @@ export default function BuildAppPageClient({
               </ul>
               <div className="flex flex-wrap gap-3">
                 <Link
-                  href={`/artikel/${articleSlug}`}
-                  onClick={handleArticleClick}
+                  href={`/kumpulan-prompt/build-app/${featuredPromptSlug}`}
+                  onClick={handleFeaturedPromptClick}
                   className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
                 >
-                  Baca panduan lengkap
+                  Baca prompt unggulan
                   <ArrowRight className="h-4 w-4" />
                 </Link>
                 <a

--- a/app/kumpulan-prompt/build-app/BuildAppPageClient.tsx
+++ b/app/kumpulan-prompt/build-app/BuildAppPageClient.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import PromptClient from '../PromptClient';
+import type { Prompt } from '@/lib/prompts';
+import PromptSubmissionForm from '@/components/PromptSubmissionForm';
+import Link from 'next/link';
+import {
+  ArrowRight,
+  FileText,
+  LineChart,
+  Send,
+  Sparkles,
+} from 'lucide-react';
+import { BUILD_APP_EVENT_CATEGORY, trackAnalyticsEvent } from '@/lib/analytics';
+
+interface BuildAppPageClientProps {
+  prompts: Prompt[];
+  articleSlug: string;
+}
+
+const sortByRecency = (items: Prompt[]) =>
+  items
+    .slice()
+    .sort((a, b) => Number(b.id) - Number(a.id));
+
+export default function BuildAppPageClient({
+  prompts: initialPrompts,
+  articleSlug,
+}: BuildAppPageClientProps) {
+  const [prompts, setPrompts] = useState(() => sortByRecency(initialPrompts));
+  const [hasTrackedFormFocus, setHasTrackedFormFocus] = useState(false);
+
+  useEffect(() => {
+    setPrompts(sortByRecency(initialPrompts));
+  }, [initialPrompts]);
+
+  useEffect(() => {
+    trackAnalyticsEvent('view_build_app_prompts', {
+      event_category: BUILD_APP_EVENT_CATEGORY,
+      view_type: 'listing',
+    });
+  }, []);
+
+  const handleArticleClick = useCallback(() => {
+    trackAnalyticsEvent('click_build_app_article', {
+      event_category: BUILD_APP_EVENT_CATEGORY,
+      article_slug: articleSlug,
+    });
+  }, [articleSlug]);
+
+  const handlePromptCreated = useCallback(
+    (prompt: Prompt) => {
+      setPrompts(previous => {
+        const filtered = previous.filter(item => item.slug !== prompt.slug);
+        return sortByRecency([prompt, ...filtered]);
+      });
+
+      trackAnalyticsEvent('submit_build_app_prompt', {
+        event_category: BUILD_APP_EVENT_CATEGORY,
+        prompt_slug: prompt.slug,
+      });
+    },
+    [],
+  );
+
+  const handleFormFocus = useCallback(() => {
+    if (hasTrackedFormFocus) {
+      return;
+    }
+
+    setHasTrackedFormFocus(true);
+    trackAnalyticsEvent('focus_build_app_submission_form', {
+      event_category: BUILD_APP_EVENT_CATEGORY,
+    });
+  }, [hasTrackedFormFocus]);
+
+  const highlightItems = useMemo(
+    () => [
+      {
+        title: 'Pipeline Analitik Lengkap',
+        description:
+          'Ringkasan eksekutif, monetisasi, kesesuaian audiens, kualitas konten, hingga analisis teknis dalam satu halaman.',
+      },
+      {
+        title: 'Integrasi Pollinations.AI',
+        description:
+          'Model dinamis, engine analisis, dan generator visual otomatis siap pakai untuk laporan AI yang kaya data.',
+      },
+      {
+        title: 'Desain Futuristik',
+        description:
+          'Glassmorphism + neumorphism dengan dark/light mode, animasi halus, tooltips, dan skeleton loading responsif.',
+      },
+      {
+        title: 'Kolaborasi & Ekspor',
+        description:
+          'Ekspor PDF/PNG, shareable link, multi-bahasa, dan analitik penggunaan untuk iterasi produk.',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-16">
+      <PromptClient
+        prompts={prompts}
+        title="Kumpulan Prompt Build App"
+        description="Kumpulan prompt terkurasi untuk membantu kamu merancang website, aplikasi, serta arsitektur produk digital dengan cepat."
+        backHref="/kumpulan-prompt"
+        backLabel="Kembali ke Kumpulan Prompt"
+        basePath="/kumpulan-prompt/build-app"
+        showSubmissionTrigger={false}
+      />
+
+      <section className="container mx-auto px-4">
+        <div className="rounded-3xl border border-indigo-200 bg-gradient-to-br from-indigo-50/80 via-white to-purple-50/80 p-8 shadow-xl backdrop-blur dark:border-indigo-900/60 dark:from-indigo-950/80 dark:via-slate-900 dark:to-purple-950/60">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
+            <div className="flex-1 space-y-6">
+              <span className="inline-flex items-center gap-2 rounded-full bg-indigo-100 px-3 py-1 text-sm font-semibold text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
+                <FileText className="h-4 w-4" />
+                Panduan Implementasi
+              </span>
+              <div>
+                <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
+                  Blueprint Analisis Konten Facebook Profesional
+                </h2>
+                <p className="mt-3 text-base text-slate-600 dark:text-slate-300">
+                  Pelajari cara membangun halaman analitik komprehensif dengan Next.js, Pollinations.AI, dan sistem tema futuristik khusus kreator serta marketer Indonesia.
+                </p>
+              </div>
+              <ul className="grid gap-4 sm:grid-cols-2">
+                {highlightItems.map(item => (
+                  <li
+                    key={item.title}
+                    className="flex items-start gap-3 rounded-2xl bg-white/80 p-4 shadow-sm backdrop-blur-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:bg-slate-900/60 dark:shadow-lg"
+                  >
+                    <Sparkles className="mt-1 h-5 w-5 text-indigo-500 dark:text-indigo-300" />
+                    <div>
+                      <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">{item.title}</h3>
+                      <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href={`/artikel/${articleSlug}`}
+                  onClick={handleArticleClick}
+                  className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                >
+                  Baca panduan lengkap
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <a
+                  href="#kirim-prompt-build-app"
+                  className="inline-flex items-center gap-2 rounded-full border border-indigo-200 px-5 py-2 text-sm font-semibold text-indigo-600 transition hover:border-indigo-300 hover:text-indigo-700 dark:border-indigo-800 dark:text-indigo-300 dark:hover:border-indigo-600 dark:hover:text-indigo-200"
+                >
+                  Kirim ide prompt
+                  <Send className="h-4 w-4" />
+                </a>
+              </div>
+            </div>
+            <div className="w-full max-w-sm self-stretch rounded-2xl border border-indigo-200 bg-white/80 p-6 shadow-lg backdrop-blur dark:border-indigo-900/60 dark:bg-slate-900/80">
+              <div className="flex items-center gap-3 text-indigo-600 dark:text-indigo-300">
+                <LineChart className="h-5 w-5" />
+                <span className="text-sm font-semibold uppercase tracking-wide">Kenapa penting?</span>
+              </div>
+              <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+                Halaman analitik Facebook membantu tim konten, agency, dan brand memahami performa real-time tanpa berpindah alat.
+              </p>
+              <ul className="mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-indigo-500"></span>
+                  Insight monetisasi lokal dengan CPM/RPM Indonesia.
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-indigo-500"></span>
+                  Heatmap waktu unggah dan benchmark industri.
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-indigo-500"></span>
+                  Mode gelap/terang untuk efisiensi tim lintas perangkat.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="kirim-prompt-build-app" className="container mx-auto px-4">
+        <div className="space-y-6 rounded-3xl border border-purple-200 bg-white/80 p-8 shadow-xl backdrop-blur dark:border-purple-900/50 dark:bg-slate-900/80">
+          <div className="max-w-3xl space-y-3">
+            <span className="inline-flex items-center gap-2 rounded-full bg-purple-100 px-3 py-1 text-sm font-semibold text-purple-700 dark:bg-purple-900/60 dark:text-purple-200">
+              <Sparkles className="h-4 w-4" />
+              Kolaborasi Komunitas
+            </span>
+            <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
+              Bagikan Prompt Build App Terbaik Versimu
+            </h2>
+            <p className="text-base text-slate-600 dark:text-slate-300">
+              Isi form di bawah untuk mengirimkan blueprint, struktur UI, atau alur sistem favoritmu. Prompt terbaik akan dipublikasikan agar bisa dipakai kreator lainnya.
+            </p>
+          </div>
+          <div onFocusCapture={handleFormFocus}>
+            <PromptSubmissionForm
+              isOpen
+              variant="page"
+              onSuccess={handlePromptCreated}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/kumpulan-prompt/build-app/[slug]/page.tsx
+++ b/app/kumpulan-prompt/build-app/[slug]/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import PromptDetailClient from '../../[slug]/PromptDetailClient';
+import { getBuildAppPromptBySlug, getBuildAppPrompts } from '@/lib/buildAppPrompts';
+
+const OG_IMAGE_URL = 'https://www.ruangriung.my.id/assets/ruangriung.png';
+const COLLECTION_PATH = '/kumpulan-prompt/build-app';
+const MAX_DESCRIPTION_LENGTH = 160;
+
+const createDescription = (content: string, title: string): string => {
+  const plainText = content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/[\*_#>~]/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
+  if (!plainText) {
+    return `${title} - Kumpulan prompt build app dari RuangRiung.`;
+  }
+
+  if (plainText.length <= MAX_DESCRIPTION_LENGTH) {
+    return plainText;
+  }
+
+  return `${plainText.slice(0, MAX_DESCRIPTION_LENGTH - 1).trimEnd()}…`;
+};
+
+const toIsoString = (value: string | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+};
+
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  const prompt = await getBuildAppPromptBySlug(params.slug);
+
+  if (!prompt) {
+    return {};
+  }
+
+  const description = createDescription(prompt.promptContent, prompt.title);
+  const canonicalUrl = `https://www.ruangriung.my.id${COLLECTION_PATH}/${prompt.slug}`;
+  const publishedTime = toIsoString(prompt.date);
+  const keywords = Array.from(
+    new Set(
+      [prompt.title, prompt.tool, ...prompt.tags].filter(
+        (keyword): keyword is string => Boolean(keyword && keyword.trim()),
+      ),
+    ),
+  );
+
+  return {
+    title: `${prompt.title} - Prompt Build App - RuangRiung`,
+    description,
+    keywords: keywords.length > 0 ? keywords : undefined,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      title: prompt.title,
+      description,
+      url: canonicalUrl,
+      type: 'article',
+      siteName: 'RuangRiung',
+      ...(publishedTime ? { publishedTime } : {}),
+      authors: [prompt.author],
+      images: [
+        {
+          url: OG_IMAGE_URL,
+          width: 1200,
+          height: 630,
+          alt: prompt.title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: prompt.title,
+      description,
+      images: [OG_IMAGE_URL],
+    },
+  };
+}
+
+export const revalidate = 0;
+
+export default async function BuildAppPromptDetailPage({ params }: { params: { slug: string } }) {
+  const prompts = await getBuildAppPrompts();
+  const prompt = prompts.find(currentPrompt => currentPrompt.slug === params.slug);
+
+  if (!prompt) {
+    notFound();
+  }
+
+  return (
+    <PromptDetailClient
+      prompt={prompt}
+      prompts={prompts}
+      collectionHref={COLLECTION_PATH}
+      collectionLabel="Kembali ke Prompt Build App"
+      detailBasePath={COLLECTION_PATH}
+      homeHref="/kumpulan-prompt"
+      homeLabel="Kembali ke Kumpulan Prompt"
+    />
+  );
+}

--- a/app/kumpulan-prompt/build-app/page.tsx
+++ b/app/kumpulan-prompt/build-app/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
-import PromptClient from '../PromptClient';
 import { getBuildAppPrompts } from '@/lib/buildAppPrompts';
+import BuildAppPageClient from './BuildAppPageClient';
+
+const BUILD_APP_ARTICLE_SLUG = 'analisis-konten-facebook-profesional';
 
 const PAGE_URL = 'https://ruangriung.my.id/kumpulan-prompt/build-app';
 const SOCIAL_IMAGE_URL = 'https://ruangriung.my.id/og-image/og-image-rr.png';
@@ -51,14 +53,6 @@ export default async function BuildAppPromptPage() {
   const prompts = await getBuildAppPrompts();
 
   return (
-    <PromptClient
-      prompts={prompts}
-      title="Kumpulan Prompt Build App"
-      description="Kumpulan prompt terkurasi untuk membantu kamu merancang website, aplikasi, serta arsitektur produk digital dengan cepat."
-      backHref="/kumpulan-prompt"
-      backLabel="Kembali ke Kumpulan Prompt"
-      basePath="/kumpulan-prompt/build-app"
-      showSubmissionTrigger={false}
-    />
+    <BuildAppPageClient prompts={prompts} articleSlug={BUILD_APP_ARTICLE_SLUG} />
   );
 }

--- a/app/kumpulan-prompt/build-app/page.tsx
+++ b/app/kumpulan-prompt/build-app/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+import PromptClient from '../PromptClient';
+import { getBuildAppPrompts } from '@/lib/buildAppPrompts';
+
+const PAGE_URL = 'https://ruangriung.my.id/kumpulan-prompt/build-app';
+const SOCIAL_IMAGE_URL = 'https://ruangriung.my.id/og-image/og-image-rr.png';
+
+export const metadata: Metadata = {
+  title: 'Kumpulan Prompt Build App & Website - RuangRiung Generator',
+  description:
+    'Temukan kumpulan prompt pilihan untuk membangun website, aplikasi, dan produk digital. Jelajahi ide struktur UI, alur UX, arsitektur backend, hingga strategi copywriting siap pakai.',
+  keywords: [
+    'prompt build website',
+    'prompt buat aplikasi',
+    'prompt UX',
+    'prompt arsitektur aplikasi',
+    'ruangriung build app',
+  ],
+  alternates: {
+    canonical: PAGE_URL,
+  },
+  openGraph: {
+    title: 'Kumpulan Prompt Build App & Website - RuangRiung Generator',
+    description:
+      'Koleksi lengkap prompt untuk merancang website, aplikasi mobile, backend, dan otomasi produk digital. Cocok untuk founder, desainer, dan developer.',
+    url: PAGE_URL,
+    siteName: 'RuangRiung AI Generator',
+    locale: 'id_ID',
+    type: 'website',
+    images: [
+      {
+        url: SOCIAL_IMAGE_URL,
+        width: 1200,
+        height: 630,
+        alt: 'Kumpulan prompt build app dari RuangRiung',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Kumpulan Prompt Build App & Website - RuangRiung Generator',
+    description:
+      'Temukan referensi prompt khusus untuk membangun website, aplikasi mobile, dan sistem backend lengkap.',
+    images: [SOCIAL_IMAGE_URL],
+  },
+};
+
+export const revalidate = 0;
+
+export default async function BuildAppPromptPage() {
+  const prompts = await getBuildAppPrompts();
+
+  return (
+    <PromptClient
+      prompts={prompts}
+      title="Kumpulan Prompt Build App"
+      description="Kumpulan prompt terkurasi untuk membantu kamu merancang website, aplikasi, serta arsitektur produk digital dengan cepat."
+      backHref="/kumpulan-prompt"
+      backLabel="Kembali ke Kumpulan Prompt"
+      basePath="/kumpulan-prompt/build-app"
+      showSubmissionTrigger={false}
+    />
+  );
+}

--- a/app/kumpulan-prompt/build-app/page.tsx
+++ b/app/kumpulan-prompt/build-app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { getBuildAppPrompts } from '@/lib/buildAppPrompts';
 import BuildAppPageClient from './BuildAppPageClient';
 
-const BUILD_APP_ARTICLE_SLUG = 'analisis-konten-facebook-profesional';
+const FEATURED_PROMPT_SLUG = 'analisis-konten-facebook-profesional';
 
 const PAGE_URL = 'https://ruangriung.my.id/kumpulan-prompt/build-app';
 const SOCIAL_IMAGE_URL = 'https://ruangriung.my.id/og-image/og-image-rr.png';
@@ -53,6 +53,9 @@ export default async function BuildAppPromptPage() {
   const prompts = await getBuildAppPrompts();
 
   return (
-    <BuildAppPageClient prompts={prompts} articleSlug={BUILD_APP_ARTICLE_SLUG} />
+    <BuildAppPageClient
+      prompts={prompts}
+      featuredPromptSlug={FEATURED_PROMPT_SLUG}
+    />
   );
 }

--- a/content/articles-md/analisis-konten-facebook-profesional.md
+++ b/content/articles-md/analisis-konten-facebook-profesional.md
@@ -1,0 +1,346 @@
+---
+title: Blueprint Analisis Konten Facebook Profesional
+date: 2025-10-16
+author: Tim RuangRiung
+category: Build App
+tags: ['Facebook', 'Pollinations', 'Next.js', 'AI Analytics']
+image: /v1/assets/ruangriung.png
+summary: Panduan lengkap membangun halaman analisis konten Facebook berbasis Next.js dengan desain futuristik, integrasi Pollinations.AI, dan fitur ekspor profesional.
+---
+
+Buatkan halaman web analisis konten Facebook profesional yang komprehensif dengan fitur-fitur berikut:
+
+## Persyaratan Teknis
+
+- **Framework:** Next.js
+- **Styling:** CSS Grid & Flexbox dengan desain glassmorphism dan neumorphism
+- **Tema:** Dark/Light mode toggle dengan transisi smooth
+- **Responsif:** Optimasi untuk desktop, tablet, dan mobile
+- **Integrasi AI:** Pollinations.AI untuk analisis otomatis
+- **Referrer:** `ruangriung.my.id`
+
+## Struktur Halaman
+
+1. **Header** dengan navigasi dan toggle dark mode
+2. **Sidebar** untuk input dan konfigurasi
+3. **Main content area** dengan dashboard analisis
+4. **Footer** dengan credits dan link penting
+
+## Fitur Utama
+
+### A. Input & Konfigurasi (Sidebar)
+
+- Input konten dan saran konten yang diproses oleh AI
+- Pilihan model AI dinamis (di-load dari `https://text.pollinations.ai/models`)
+- Parameter konfigurasi AI (`temperature`, `max_tokens`, dll)
+- Target audiens (default: Indonesia)
+- Toggle untuk fitur analisis spesifik
+
+### B. Dashboard Analisis (Main Content)
+
+#### 1. Ringkasan Eksekutif
+
+- Skor keseluruhan (0-100) dengan visual meter
+- Status: Excellent/Good/Fair/Poor
+- Rekomendasi utama
+
+#### 2. Analisis Monetisasi
+
+- Prediksi CPM (Cost Per Mille) untuk Indonesia
+- Estimasi RPM (Revenue Per Mille)
+- Prediksi CTR (Click-Through Rate)
+- Estimasi pendapatan per 1000 views
+- Grafik perbandingan dengan standar industri
+
+#### 3. Analisis Kesesuaian Audiens Indonesia
+
+- Skor relevansi budaya (0-100)
+- Analisis bahasa dan istilah
+- Kesesuaian dengan tren lokal
+- Heatmap waktu posting optimal untuk Indonesia
+
+#### 4. Analisis Kualitas Konten
+
+- **Insight:** Pola performa dan prediksi viralitas
+- **Orisinalitas:** Tingkat keunikan konten
+- **Relevansi:** Keterkaitan dengan niche
+- **Visualitas:** Kualitas elemen visual
+- **Niche Analysis:** Positioning dalam market
+
+#### 5. Analisis Teknis
+
+- Optimasi hashtag dan tags
+- Jam tayang terbaik berdasarkan data historis
+- Frekuensi posting ideal
+- Estimasi jangkauan organik vs berbayar
+
+### C. Integrasi Pollinations.AI
+
+#### 1. Dynamic Model Loading
+
+```javascript
+// Auto-load available models from Pollinations.AI
+fetch('https://text.pollinations.ai/models')
+  .then(response => response.json())
+  .then(models => {
+    // Populate model selection dropdown
+    updateModelSelector(models);
+  });
+```
+
+#### 2. AI Analysis Engine
+
+```javascript
+async function analyzeContent(facebookData) {
+  const analysisPrompt = `
+    Analisis konten Facebook berikut untuk audiens Indonesia:
+    
+    JUDUL: ${facebookData.title}
+    DESKRIPSI: ${facebookData.description}
+    JENIS KONTEN: ${facebookData.type}
+    TARGET: ${facebookData.audience}
+    
+    Berikan analisis dalam format JSON dengan struktur:
+    {
+      "overall_score": 0-100,
+      "monetization_analysis": {
+        "predicted_cpm": number,
+        "predicted_rpm": number, 
+        "predicted_ctr": number,
+        "revenue_estimate": string,
+        "monetization_potential": "Low/Medium/High"
+      },
+      "audience_suitability": {
+        "cultural_relevance_score": 0-100,
+        "language_analysis": string,
+        "local_trend_alignment": string,
+        "recommendations": array
+      },
+      "content_quality": {
+        "originality_score": 0-100,
+        "relevance_score": 0-100, 
+        "visual_quality_score": 0-100,
+        "insights": string,
+        "niche_analysis": string
+      },
+      "technical_analysis": {
+        "optimal_posting_times": array,
+        "hashtag_recommendations": array,
+        "reach_estimates": {
+          "organic": string,
+          "paid": string
+        }
+      },
+      "improvement_suggestions": array
+    }
+  `;
+
+  const response = await fetch('https://text.pollinations.ai/openai', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Referrer': 'ruangriung.my.id'
+    },
+    body: JSON.stringify({
+      model: selectedModel, // Dynamic model selection
+      messages: [
+        {
+          role: "system",
+          content: "Anda adalah ahli analisis media sosial khusus pasar Indonesia. Berikan analisis yang mendalam dan actionable dalam format JSON yang terstruktur."
+        },
+        {
+          role: "user", 
+          content: analysisPrompt
+        }
+      ],
+      temperature: 0.7,
+      max_tokens: 2000
+    })
+  });
+
+  return await response.json();
+}
+```
+
+#### 3. Image Generation untuk Visualisasi
+
+```javascript
+function generateAnalysisChart(type, data) {
+  const prompt = `Create a professional ${type} chart visualization for: ${JSON.stringify(data)}`;
+  const chartUrl = `https://image.pollinations.ai/prompt/${encodeURIComponent(prompt)}?width=800&height=400&model=flux&referrer=ruangriung.my.id`;
+  return chartUrl;
+}
+```
+
+## UI/UX Requirements
+
+### Dark Mode Design
+
+- Primary: `#1a1a1a`
+- Secondary: `#2d2d2d`
+- Accent: `#6366f1`
+- Text: `#f8fafc`
+
+### Light Mode Design
+
+- Primary: `#ffffff`
+- Secondary: `#f8fafc`
+- Accent: `#4f46e5`
+- Text: `#1e293b`
+
+### Komponen UI
+
+- Cards dengan efek glassmorphism
+- Progress bars animasi untuk skor
+- Tooltips informatif di setiap indikator
+- Loading skeletons untuk data AI
+- Error boundaries dengan fallback elegan
+- Fitur ekspor (PDF/PNG)
+
+### Animasi
+
+- Fade in pada hasil analisis
+- Transisi smooth antar section
+- Hover effects pada elemen interaktif
+- Loading animations khusus AI
+
+## Contoh Output Visual
+
+1. **Score Cards**
+
+```
+[🟢 Overall Score: 85/100] [🟡 Monetization: 78/100] [🔵 Audience Fit: 92/100]
+```
+
+2. **Revenue Prediction Chart**
+
+```
+Bar chart comparing: Organic vs Paid revenue potential
+Line chart: CPM trends over time for Indonesian market
+```
+
+3. **Audience Heatmap**
+
+```
+Heatmap showing optimal posting times for Indonesian audience
+[🟦][🟦][🟩][🟩][🟥][🟥] - 24 hour distribution
+```
+
+4. **Improvement Recommendations**
+
+```
+✅ Tambahkan hashtag #TrenIndonesia
+✅ Optimalkan posting jam 19:00-21:00 WIB  
+❌ Kurangi penggunaan bahasa asing berlebihan
+```
+
+## Fitur Tambahan
+
+### Real-time Analysis
+
+- Live preview saat input berubah
+- Debounced API calls
+- Caching untuk performa
+
+### Comparative Analysis
+
+- Bandingkan dengan konten sejenis
+- Historical performance tracking
+- Industry benchmark comparison
+
+### Export & Share
+
+- Generate laporan PDF
+- Shareable links
+- Social media preview
+
+### Multi-language Support
+
+- Bahasa Indonesia (utama)
+- Bahasa Inggris (sekunder)
+
+### Error Handling
+
+- Graceful API failure handling
+- User-friendly error messages
+- Retry mechanisms
+- Offline capability untuk fitur dasar
+
+### Performance Optimization
+
+- Lazy loading untuk charts
+- Image optimization
+- Code splitting
+- CDN untuk assets
+
+Tambahkan juga analytics tracking untuk monitoring usage patterns dan improvement opportunities.
+
+## Poin Implementasi Khusus
+
+### 1. Dynamic Model Integration
+
+```javascript
+// Model manager class
+class ModelManager {
+  constructor() {
+    this.availableModels = [];
+    this.currentModel = 'openai';
+  }
+
+  async loadModels() {
+    try {
+      const response = await fetch('https://text.pollinations.ai/models');
+      this.availableModels = await response.json();
+      this.updateUI();
+    } catch (error) {
+      console.error('Failed to load models:', error);
+    }
+  }
+}
+```
+
+### 2. Theme System
+
+```javascript
+// Theme manager dengan localStorage persistence
+class ThemeManager {
+  constructor() {
+    this.currentTheme = localStorage.getItem('theme') || 'light';
+    this.init();
+  }
+
+  toggleTheme() {
+    this.currentTheme = this.currentTheme === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', this.currentTheme);
+    localStorage.setItem('theme', this.currentTheme);
+  }
+}
+```
+
+### 3. Analysis Pipeline
+
+```javascript
+// Main analysis workflow
+class FacebookAnalyzer {
+  async analyze(facebookUrl) {
+    this.showLoading();
+    
+    try {
+      // Extract data from Facebook URL
+      const contentData = await this.extractContent(facebookUrl);
+      
+      // Get AI analysis
+      const aiAnalysis = await this.getAIAnalysis(contentData);
+      
+      // Generate visualizations
+      const charts = await this.generateCharts(aiAnalysis);
+      
+      // Render results
+      this.renderAnalysis(aiAnalysis, charts);
+      
+    } catch (error) {
+      this.showError(error);
+    }
+  }
+}
+```

--- a/content/build-app-prompts/analisis-konten-facebook-profesional.md
+++ b/content/build-app-prompts/analisis-konten-facebook-profesional.md
@@ -4,7 +4,7 @@ slug: "analisis-konten-facebook-profesional"
 title: "Blueprint Analisis Konten Facebook Profesional"
 author: "ruangriung team"
 date: "2025-10-17"
-tool: "deepseek"
+tool: "Google AI Studio, Vercel Bot"
 tags:
   - analitik konten
   - facebook

--- a/content/build-app-prompts/analisis-konten-facebook-profesional.md
+++ b/content/build-app-prompts/analisis-konten-facebook-profesional.md
@@ -2,9 +2,9 @@
 id: "11"
 slug: "analisis-konten-facebook-profesional"
 title: "Blueprint Analisis Konten Facebook Profesional"
-author: "RuangRiung Studio"
-date: "2024-03-12"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "deepseek"
 tags:
   - analitik konten
   - facebook

--- a/content/build-app-prompts/analisis-konten-facebook-profesional.md
+++ b/content/build-app-prompts/analisis-konten-facebook-profesional.md
@@ -1,83 +1,76 @@
 ---
-title: Blueprint Analisis Konten Facebook Profesional
-date: 2025-10-16
-author: Tim RuangRiung
-category: Build App
-tags: ['Facebook', 'Pollinations', 'Next.js', 'AI Analytics']
-image: /v1/assets/ruangriung.png
-summary: Panduan lengkap membangun halaman analisis konten Facebook berbasis Next.js dengan desain futuristik, integrasi Pollinations.AI, dan fitur ekspor profesional.
+id: "11"
+slug: "analisis-konten-facebook-profesional"
+title: "Blueprint Analisis Konten Facebook Profesional"
+author: "RuangRiung Studio"
+date: "2024-03-12"
+tool: "ChatGPT"
+tags:
+  - analitik konten
+  - facebook
+  - aplikasi web
+  - pollinations
 ---
-
 Buatkan halaman web analisis konten Facebook profesional yang komprehensif dengan fitur-fitur berikut:
 
-## Persyaratan Teknis
+## Persyaratan Teknis:
+- Framework: next js
+- Styling: CSS Grid & Flexbox dengan desain glassmorphism dan neumorphism
+- Dark/Light mode toggle dengan transisi smooth
+- Responsif untuk desktop, tablet, dan mobile
+- Integrasi dengan Pollinations.AI API untuk analisis AI
+- Referrer: ruangriung.my.id
 
-- **Framework:** Next.js
-- **Styling:** CSS Grid & Flexbox dengan desain glassmorphism dan neumorphism
-- **Tema:** Dark/Light mode toggle dengan transisi smooth
-- **Responsif:** Optimasi untuk desktop, tablet, dan mobile
-- **Integrasi AI:** Pollinations.AI untuk analisis otomatis
-- **Referrer:** `ruangriung.my.id`
+## Struktur Halaman:
+1. Header dengan navigasi dan toggle dark mode
+2. Sidebar untuk input dan konfigurasi
+3. Main content area dengan dashboard analisis
+4. Footer dengan credits dan link
 
-## Struktur Halaman
+## Fitur Utama:
 
-1. **Header** dengan navigasi dan toggle dark mode
-2. **Sidebar** untuk input dan konfigurasi
-3. **Main content area** dengan dashboard analisis
-4. **Footer** dengan credits dan link penting
-
-## Fitur Utama
-
-### A. Input & Konfigurasi (Sidebar)
-
-- Input konten dan saran konten yang diproses oleh AI
-- Pilihan model AI dinamis (di-load dari `https://text.pollinations.ai/models`)
-- Parameter konfigurasi AI (`temperature`, `max_tokens`, dll)
+### A. Input & Konfigurasi (Sidebar):
+- Input konten dan saran konten yang di diproses oleh AI 
+- Pilihan model AI dinamis (di-load dari https://text.pollinations.ai/models)
+- Parameter konfigurasi AI (temperature, max_tokens, dll)
 - Target audiens (default: Indonesia)
 - Toggle untuk fitur analisis spesifik
 
-### B. Dashboard Analisis (Main Content)
-
+### B. Dashboard Analisis (Main Content):
 #### 1. Ringkasan Eksekutif
-
 - Skor keseluruhan (0-100) dengan visual meter
 - Status: Excellent/Good/Fair/Poor
 - Rekomendasi utama
 
 #### 2. Analisis Monetisasi
-
 - Prediksi CPM (Cost Per Mille) untuk Indonesia
 - Estimasi RPM (Revenue Per Mille)
-- Prediksi CTR (Click-Through Rate)
+- CTR (Click-Through Rate) prediksi
 - Estimasi pendapatan per 1000 views
 - Grafik perbandingan dengan standar industri
 
 #### 3. Analisis Kesesuaian Audiens Indonesia
-
 - Skor relevansi budaya (0-100)
 - Analisis bahasa dan istilah
 - Kesesuaian dengan tren lokal
 - Heatmap waktu posting optimal untuk Indonesia
 
 #### 4. Analisis Kualitas Konten
-
-- **Insight:** Pola performa dan prediksi viralitas
-- **Orisinalitas:** Tingkat keunikan konten
-- **Relevansi:** Keterkaitan dengan niche
-- **Visualitas:** Kualitas elemen visual
-- **Niche Analysis:** Positioning dalam market
+- **Insight**: Pola performa dan prediksi viralitas
+- **Orisinalitas**: Tingkat keunikan konten
+- **Relevansi**: Keterkaitan dengan niche
+- **Visualitas**: Kualitas elemen visual
+- **Niche Analysis**: Positioning dalam market
 
 #### 5. Analisis Teknis
-
 - Optimasi hashtag dan tags
 - Jam tayang terbaik berdasarkan data historis
 - Frekuensi posting ideal
 - Estimasi jangkauan organik vs berbayar
 
-### C. Integrasi Pollinations.AI
+### C. Integrasi Pollinations.AI:
 
-#### 1. Dynamic Model Loading
-
+#### 1. Dynamic Model Loading:
 ```javascript
 // Auto-load available models from Pollinations.AI
 fetch('https://text.pollinations.ai/models')
@@ -88,7 +81,7 @@ fetch('https://text.pollinations.ai/models')
   });
 ```
 
-#### 2. AI Analysis Engine
+2. AI Analysis Engine:
 
 ```javascript
 async function analyzeContent(facebookData) {
@@ -162,7 +155,7 @@ async function analyzeContent(facebookData) {
 }
 ```
 
-#### 3. Image Generation untuk Visualisasi
+3. Image Generation untuk Visualisasi:
 
 ```javascript
 function generateAnalysisChart(type, data) {
@@ -172,61 +165,61 @@ function generateAnalysisChart(type, data) {
 }
 ```
 
-## UI/UX Requirements
+UI/UX Requirements:
 
-### Dark Mode Design
+Dark Mode Design:
 
-- Primary: `#1a1a1a`
-- Secondary: `#2d2d2d`
-- Accent: `#6366f1`
-- Text: `#f8fafc`
+· Primary: #1a1a1a
+· Secondary: #2d2d2d
+· Accent: #6366f1
+· Text: #f8fafc
 
-### Light Mode Design
+Light Mode Design:
 
-- Primary: `#ffffff`
-- Secondary: `#f8fafc`
-- Accent: `#4f46e5`
-- Text: `#1e293b`
+· Primary: #ffffff
+· Secondary: #f8fafc
+· Accent: #4f46e5
+· Text: #1e293b
 
-### Komponen UI
+Komponen UI:
 
-- Cards dengan efek glassmorphism
-- Progress bars animasi untuk skor
-- Tooltips informatif di setiap indikator
-- Loading skeletons untuk data AI
-- Error boundaries dengan fallback elegan
-- Fitur ekspor (PDF/PNG)
+· Cards dengan glassmorphism effect
+· Progress bars animasi untuk scores
+· Tooltips informatif
+· Loading skeletons
+· Error boundaries
+· Export functionality (PDF/PNG)
 
-### Animasi
+Animasi:
 
-- Fade in pada hasil analisis
-- Transisi smooth antar section
-- Hover effects pada elemen interaktif
-- Loading animations khusus AI
+· Fade in pada hasil analisis
+· Smooth transitions antara sections
+· Hover effects pada interactive elements
+· Loading animations
 
-## Contoh Output Visual
+Contoh Output Visual:
 
-1. **Score Cards**
+1. Score Cards:
 
 ```
 [🟢 Overall Score: 85/100] [🟡 Monetization: 78/100] [🔵 Audience Fit: 92/100]
 ```
 
-2. **Revenue Prediction Chart**
+2. Revenue Prediction Chart:
 
 ```
 Bar chart comparing: Organic vs Paid revenue potential
 Line chart: CPM trends over time for Indonesian market
 ```
 
-3. **Audience Heatmap**
+3. Audience Heatmap:
 
 ```
 Heatmap showing optimal posting times for Indonesian audience
 [🟦][🟦][🟩][🟩][🟥][🟥] - 24 hour distribution
 ```
 
-4. **Improvement Recommendations**
+4. Improvement Recommendations:
 
 ```
 ✅ Tambahkan hashtag #TrenIndonesia
@@ -234,51 +227,54 @@ Heatmap showing optimal posting times for Indonesian audience
 ❌ Kurangi penggunaan bahasa asing berlebihan
 ```
 
-## Fitur Tambahan
+Fitur Tambahan:
 
-### Real-time Analysis
+Real-time Analysis:
 
-- Live preview saat input berubah
-- Debounced API calls
-- Caching untuk performa
+· Live preview saat input berubah
+· Debounced API calls
+· Caching untuk performa
 
-### Comparative Analysis
+Comparative Analysis:
 
-- Bandingkan dengan konten sejenis
-- Historical performance tracking
-- Industry benchmark comparison
+· Bandingkan dengan konten sejenis
+· Historical performance tracking
+· Industry benchmark comparison
 
-### Export & Share
+Export & Share:
 
-- Generate laporan PDF
-- Shareable links
-- Social media preview
+· Generate laporan PDF
+· Shareable links
+· Social media preview
 
-### Multi-language Support
+Multi-language Support:
 
-- Bahasa Indonesia (utama)
-- Bahasa Inggris (sekunder)
+· Indonesia (primary)
+· English (secondary)
 
-### Error Handling
+Error Handling:
 
-- Graceful API failure handling
-- User-friendly error messages
-- Retry mechanisms
-- Offline capability untuk fitur dasar
+· Graceful API failure handling
+· User-friendly error messages
+· Retry mechanisms
+· Offline capability untuk basic features
 
-### Performance Optimization
+Performance Optimization:
 
-- Lazy loading untuk charts
-- Image optimization
-- Code splitting
-- CDN untuk assets
+· Lazy loading untuk charts
+· Image optimization
+· Code splitting
+· CDN untuk assets
+
+Buat kode yang clean, modular, dan well-documented. Gunakan modern JavaScript practices dengan async/await, proper error handling, dan responsive design principles.
 
 Tambahkan juga analytics tracking untuk monitoring usage patterns dan improvement opportunities.
 
-## Poin Implementasi Khusus
+```
 
-### 1. Dynamic Model Integration
+## Poin Implementasi Khusus:
 
+### 1. Dynamic Model Integration:
 ```javascript
 // Model manager class
 class ModelManager {
@@ -299,7 +295,7 @@ class ModelManager {
 }
 ```
 
-### 2. Theme System
+2. Theme System:
 
 ```javascript
 // Theme manager dengan localStorage persistence
@@ -317,7 +313,7 @@ class ThemeManager {
 }
 ```
 
-### 3. Analysis Pipeline
+3. Analysis Pipeline:
 
 ```javascript
 // Main analysis workflow
@@ -330,6 +326,7 @@ class FacebookAnalyzer {
       const contentData = await this.extractContent(facebookUrl);
       
       // Get AI analysis
+
       const aiAnalysis = await this.getAIAnalysis(contentData);
       
       // Generate visualizations

--- a/content/build-app-prompts/prompt-1.md
+++ b/content/build-app-prompts/prompt-1.md
@@ -1,0 +1,13 @@
+---
+id: "1"
+slug: "landing-page-saas-ai"
+title: "Landing Page SaaS AI yang Memukau"
+author: "RuangRiung Studio"
+date: "2024-02-15"
+tool: "ChatGPT"
+tags:
+  - website
+  - landing page
+  - saas
+---
+Kamu adalah UI/UX writer profesional untuk startup SaaS AI. Buatkan struktur copy lengkap untuk landing page modern: hero section dengan nilai jual utama, ringkasan fitur, social proof, paket harga, FAQ, dan CTA akhir. Tulis dalam bahasa Indonesia yang persuasif, sertakan judul dan subjudul untuk setiap bagian, arahkan agar mudah dikonversi ke komponen React.

--- a/content/build-app-prompts/prompt-1.md
+++ b/content/build-app-prompts/prompt-1.md
@@ -2,9 +2,9 @@
 id: "1"
 slug: "landing-page-saas-ai"
 title: "Landing Page SaaS AI yang Memukau"
-author: "RuangRiung Studio"
-date: "2024-02-15"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "Google Gemini"
 tags:
   - website
   - landing page

--- a/content/build-app-prompts/prompt-10.md
+++ b/content/build-app-prompts/prompt-10.md
@@ -1,0 +1,13 @@
+---
+id: "10"
+slug: "alur-prototipe-chatbot"
+title: "Alur Prototipe Chatbot Layanan Pelanggan"
+author: "Raka Suryana"
+date: "2024-05-12"
+tool: "ChatGPT"
+tags:
+  - chatbot
+  - customer service
+  - automation
+---
+Sebagai konsultan CX, buat alur prototipe chatbot layanan pelanggan untuk bisnis e-commerce. Definisikan persona pengguna, daftar intent utama, contoh percakapan multi-turn, integrasi dengan sistem tiket, dan fallback ke agen manusia. Sertakan juga metrik evaluasi (CSAT, FRT) dan rencana iterasi berdasarkan feedback.

--- a/content/build-app-prompts/prompt-10.md
+++ b/content/build-app-prompts/prompt-10.md
@@ -2,9 +2,9 @@
 id: "10"
 slug: "alur-prototipe-chatbot"
 title: "Alur Prototipe Chatbot Layanan Pelanggan"
-author: "Raka Suryana"
-date: "2024-05-12"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "Google AI Studio"
 tags:
   - chatbot
   - customer service

--- a/content/build-app-prompts/prompt-2.md
+++ b/content/build-app-prompts/prompt-2.md
@@ -2,9 +2,9 @@
 id: "2"
 slug: "dashboard-analytics-tailwind"
 title: "Template Dashboard Analytics dengan Tailwind"
-author: "Nala Pradipta"
-date: "2024-03-02"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "chatgpt"
 tags:
   - dashboard
   - tailwindcss

--- a/content/build-app-prompts/prompt-2.md
+++ b/content/build-app-prompts/prompt-2.md
@@ -1,0 +1,13 @@
+---
+id: "2"
+slug: "dashboard-analytics-tailwind"
+title: "Template Dashboard Analytics dengan Tailwind"
+author: "Nala Pradipta"
+date: "2024-03-02"
+tool: "ChatGPT"
+tags:
+  - dashboard
+  - tailwindcss
+  - react
+---
+Sebagai senior frontend engineer, buatkan blueprint komponen dashboard analytics untuk React + Tailwind CSS. Jelaskan hierarki layout, daftar komponen reusable (card metrik, grafik area, tabel aktivitas), state global yang dibutuhkan, serta saran API mock. Sertakan juga contoh struktur folder project dan nama class Tailwind utama untuk setiap komponen.

--- a/content/build-app-prompts/prompt-3.md
+++ b/content/build-app-prompts/prompt-3.md
@@ -1,0 +1,13 @@
+---
+id: "3"
+slug: "aplikasi-mobile-belanja-ux"
+title: "Flow UX Aplikasi Belanja Mobile"
+author: "Sinta Hapsari"
+date: "2024-01-28"
+tool: "ChatGPT"
+tags:
+  - mobile
+  - ux
+  - product
+---
+Bertindak sebagai UX lead, susun flow end-to-end aplikasi belanja mobile: onboarding, katalog produk, keranjang, checkout, pelacakan pesanan, dan loyalty program. Untuk setiap layar berikan tujuan, elemen penting, microcopy, serta rekomendasi interaksi. Output dalam format markdown dengan heading jelas agar dapat langsung diterjemahkan ke wireframe Figma.

--- a/content/build-app-prompts/prompt-3.md
+++ b/content/build-app-prompts/prompt-3.md
@@ -2,9 +2,9 @@
 id: "3"
 slug: "aplikasi-mobile-belanja-ux"
 title: "Flow UX Aplikasi Belanja Mobile"
-author: "Sinta Hapsari"
-date: "2024-01-28"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "github copilot"
 tags:
   - mobile
   - ux

--- a/content/build-app-prompts/prompt-4.md
+++ b/content/build-app-prompts/prompt-4.md
@@ -1,0 +1,13 @@
+---
+id: "4"
+slug: "api-spec-event-booking"
+title: "Spesifikasi API Platform Booking Event"
+author: "RuangRiung Lab"
+date: "2024-04-10"
+tool: "ChatGPT"
+tags:
+  - api
+  - backend
+  - documentation
+---
+Sebagai arsitek backend, buatkan spesifikasi API REST untuk platform booking event. Sertakan daftar endpoint CRUD untuk event, tiket, pengguna, dan pembayaran. Jelaskan skema request/response JSON, status code, strategi autentikasi, serta contoh sequence flow pemesanan tiket. Formatkan dengan tabel markdown agar mudah dipindahkan ke dokumentasi OpenAPI.

--- a/content/build-app-prompts/prompt-4.md
+++ b/content/build-app-prompts/prompt-4.md
@@ -2,9 +2,9 @@
 id: "4"
 slug: "api-spec-event-booking"
 title: "Spesifikasi API Platform Booking Event"
-author: "RuangRiung Lab"
-date: "2024-04-10"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "Google AI Studio"
 tags:
   - api
   - backend

--- a/content/build-app-prompts/prompt-5.md
+++ b/content/build-app-prompts/prompt-5.md
@@ -1,0 +1,13 @@
+---
+id: "5"
+slug: "design-system-komponen"
+title: "Checklist Design System Komponen UI"
+author: "Anya Wirawan"
+date: "2024-02-01"
+tool: "ChatGPT"
+tags:
+  - design system
+  - components
+  - documentation
+---
+Kamu adalah product designer yang menyusun design system. Buatkan checklist dokumentasi untuk komponen inti (button, input, modal, navbar, card). Untuk setiap komponen jelaskan variasi state, token desain, pedoman aksesibilitas, contoh kode React/Tailwind, serta aturan kapan komponen digunakan. Sajikan dalam format tabel dan bullet agar mudah dimasukkan ke Notion.

--- a/content/build-app-prompts/prompt-5.md
+++ b/content/build-app-prompts/prompt-5.md
@@ -2,9 +2,9 @@
 id: "5"
 slug: "design-system-komponen"
 title: "Checklist Design System Komponen UI"
-author: "Anya Wirawan"
-date: "2024-02-01"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "Manus AI"
 tags:
   - design system
   - components

--- a/content/build-app-prompts/prompt-6.md
+++ b/content/build-app-prompts/prompt-6.md
@@ -2,9 +2,9 @@
 id: "6"
 slug: "copywriting-aplikasi-keuangan"
 title: "Copywriting Aplikasi Keuangan Pribadi"
-author: "Diva Hartanto"
-date: "2024-05-05"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "Codex by ChatGPT"
 tags:
   - copywriting
   - finance app

--- a/content/build-app-prompts/prompt-6.md
+++ b/content/build-app-prompts/prompt-6.md
@@ -1,0 +1,13 @@
+---
+id: "6"
+slug: "copywriting-aplikasi-keuangan"
+title: "Copywriting Aplikasi Keuangan Pribadi"
+author: "Diva Hartanto"
+date: "2024-05-05"
+tool: "ChatGPT"
+tags:
+  - copywriting
+  - finance app
+  - marketing
+---
+Sebagai copywriter fintech, tulis konten lengkap untuk website aplikasi keuangan pribadi: tagline hero, keunggulan fitur budgeting, keamanan data, testimoni pengguna, dan CTA download mobile app. Gunakan tone profesional namun bersahabat, sertakan angka statistik untuk meningkatkan kredibilitas, dan susun agar kompatibel dengan layout satu halaman.

--- a/content/build-app-prompts/prompt-7.md
+++ b/content/build-app-prompts/prompt-7.md
@@ -1,0 +1,13 @@
+---
+id: "7"
+slug: "arsitektur-microservice-marketplace"
+title: "Arsitektur Microservice Marketplace"
+author: "Bagus Prakoso"
+date: "2024-03-18"
+tool: "ChatGPT"
+tags:
+  - architecture
+  - microservice
+  - marketplace
+---
+Berperan sebagai solution architect, desain arsitektur microservice untuk marketplace UMKM. Jelaskan pembagian service (catalog, order, payment, notification), pilihan teknologi (database, message broker, cache), pola komunikasi sinkron/asinkron, strategi deployment di Kubernetes, serta observability stack. Tulis ringkasan diagram arsitektur dalam bentuk deskripsi teks.

--- a/content/build-app-prompts/prompt-7.md
+++ b/content/build-app-prompts/prompt-7.md
@@ -2,9 +2,9 @@
 id: "7"
 slug: "arsitektur-microservice-marketplace"
 title: "Arsitektur Microservice Marketplace"
-author: "Bagus Prakoso"
-date: "2024-03-18"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "BlackBox AI"
 tags:
   - architecture
   - microservice

--- a/content/build-app-prompts/prompt-8.md
+++ b/content/build-app-prompts/prompt-8.md
@@ -1,0 +1,13 @@
+---
+id: "8"
+slug: "alur-ci-cd-monorepo"
+title: "Alur CI/CD untuk Monorepo"
+author: "Yanuar Mahesa"
+date: "2024-04-27"
+tool: "ChatGPT"
+tags:
+  - devops
+  - ci/cd
+  - monorepo
+---
+Sebagai DevOps engineer, rancang pipeline CI/CD GitHub Actions untuk monorepo berisi aplikasi web Next.js dan service Node.js. Jelaskan job build, lint, test, deployment ke Vercel dan Fly.io, strategi caching dependencies, serta aturan branching. Sertakan contoh file YAML dengan komentar agar mudah disesuaikan tim kecil.

--- a/content/build-app-prompts/prompt-8.md
+++ b/content/build-app-prompts/prompt-8.md
@@ -2,9 +2,9 @@
 id: "8"
 slug: "alur-ci-cd-monorepo"
 title: "Alur CI/CD untuk Monorepo"
-author: "Yanuar Mahesa"
-date: "2024-04-27"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "Emergent.sh"
 tags:
   - devops
   - ci/cd

--- a/content/build-app-prompts/prompt-9.md
+++ b/content/build-app-prompts/prompt-9.md
@@ -1,0 +1,13 @@
+---
+id: "9"
+slug: "pwa-event-community"
+title: "Blueprint PWA Komunitas Event"
+author: "Galang Novera"
+date: "2024-01-12"
+tool: "ChatGPT"
+tags:
+  - pwa
+  - offline-first
+  - community
+---
+Sebagai product manager, jelaskan blueprint pengembangan Progressive Web App untuk komunitas event lokal. Detailkan fitur prioritas (kalender, RSVP, chat, ticket QR), kebutuhan offline-first, strategi push notification, serta integrasi dengan Google Calendar. Berikan rekomendasi backlog sprint pertama dan metrik keberhasilan utama.

--- a/content/build-app-prompts/prompt-9.md
+++ b/content/build-app-prompts/prompt-9.md
@@ -2,9 +2,9 @@
 id: "9"
 slug: "pwa-event-community"
 title: "Blueprint PWA Komunitas Event"
-author: "Galang Novera"
-date: "2024-01-12"
-tool: "ChatGPT"
+author: "ruangriung team"
+date: "2025-10-17"
+tool: "deepseek"
 tags:
   - pwa
   - offline-first

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,26 @@
+export type AnalyticsEventPayload = Record<string, unknown> | undefined;
+
+type WindowWithGtag = Window & {
+  gtag?: (...args: unknown[]) => void;
+};
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+export const trackAnalyticsEvent = (eventName: string, payload?: Record<string, unknown>) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const { gtag } = window as WindowWithGtag;
+
+  if (typeof gtag !== 'function') {
+    if (isDevelopment) {
+      console.debug('[analytics] gtag unavailable, skipped event', eventName, payload);
+    }
+    return;
+  }
+
+  gtag('event', eventName, payload ?? {});
+};
+
+export const BUILD_APP_EVENT_CATEGORY = 'build_app_prompts';

--- a/lib/buildAppPrompts.ts
+++ b/lib/buildAppPrompts.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+import { getPromptsFromDirectory, Prompt } from './prompts';
+
+const buildAppPromptsDirectory = path.join(process.cwd(), 'content/build-app-prompts');
+
+export const getBuildAppPrompts = async (): Promise<Prompt[]> => {
+  return getPromptsFromDirectory(buildAppPromptsDirectory);
+};
+
+export const getBuildAppPromptBySlug = async (slug: string): Promise<Prompt | undefined> => {
+  const prompts = await getBuildAppPrompts();
+  return prompts.find(prompt => prompt.slug === slug);
+};


### PR DESCRIPTION
## Summary
- add a dedicated build-app prompt listing and detail route under `/kumpulan-prompt`
- make the shared prompt list/detail clients configurable for custom titles and navigation paths
- seed the build-app collection with curated markdown prompts and loader utilities

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f14a017a58832e84919e8fffc74da0