### PR TITLE
Normalize Nodemailer app password input

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -11,6 +11,13 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const sanitizeString = (value: unknown): string =>
   typeof value === 'string' ? value.trim() : '';
 
+const collapseWhitespace = (value: string) => value.replace(/\s+/g, '');
+
+export const sanitizeAppPassword = (value: unknown): string => {
+  const sanitized = sanitizeString(value);
+  return collapseWhitespace(sanitized);
+};
+
 export const normalizeEmailAddress = (value: unknown): NormalizedEmail | null => {
   if (typeof value !== 'string') {
     return null;
@@ -145,7 +152,7 @@ export const createTransportOptions = (user: string, pass: string): SMTPTranspor
 
 export const createEmailTransporter = () => {
   const nodemailerUser = sanitizeEmail(process.env.NODEMAILER_EMAIL);
-  const nodemailerPass = sanitizeString(process.env.NODEMAILER_APP_PASSWORD);
+  const nodemailerPass = sanitizeAppPassword(process.env.NODEMAILER_APP_PASSWORD);
 
   if (!nodemailerUser || !nodemailerPass) {
     throw new Error('NODEMAILER_EMAIL atau NODEMAILER_APP_PASSWORD belum dikonfigurasi dengan benar.');


### PR DESCRIPTION
## Summary
- remove all whitespace characters from the configured Nodemailer app password before creating the transporter
- reuse the sanitized password across every email form submission so copied Gmail app passwords continue to work after being rotated

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f8015bb8cc832e8c84d70cdc4ad5c9