### PR TITLE
Handle whitespace in mail app password more flexibly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ NEXT_PUBLIC_POLLINATIONS_TOKEN=
 PROMPT_EDIT_TOKEN=
 ```
 
-Variabel tambahan mungkin diperlukan untuk fitur tertentu seperti formulir kontak atau iklan.
+Variabel tambahan mungkin diperlukan untuk fitur tertentu seperti formulir kontak atau iklan. Anda juga dapat menambahkan
+akhiran khusus (misalnya `NODEMAILER_EMAIL_AYICKTIGABELAS` dan `NODEMAILER_APP_PASSWORD_AYICKTIGABELAS`) bila perlu
+menyimpan beberapa kredensial; aplikasi akan otomatis menggunakan nilai pertama yang tersedia dengan awalan tersebut.
 
 ## Konten
 Artikel dan contoh prompt berada pada direktori `content` dan dimuat dari berkas Markdown.

--- a/app/api/submit-prompt/route.ts
+++ b/app/api/submit-prompt/route.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { createPrompt } from '@/lib/prompts';
 import {
   createEmailTransporter,
+  resolveMailEnvValue,
   sanitizeEmail,
   sanitizeEmailAddresses,
   sanitizeSenderAddress,
@@ -127,10 +128,13 @@ export async function POST(request: Request) {
         );
       }
 
-      const senderAddress = sanitizeSenderAddress(process.env.NODEMAILER_FROM, nodemailerUser);
+      const senderAddress = sanitizeSenderAddress(
+        resolveMailEnvValue('NODEMAILER_FROM'),
+        nodemailerUser,
+      );
       const recipientAddresses = sanitizeEmailAddresses([
-        process.env.PROMPT_SUBMISSION_RECIPIENT,
-        process.env.CONTACT_EMAIL_RECIPIENT,
+        resolveMailEnvValue('PROMPT_SUBMISSION_RECIPIENT'),
+        resolveMailEnvValue('CONTACT_EMAIL_RECIPIENT'),
         nodemailerUser,
         DEFAULT_PROMPT_NOTIFICATION_EMAIL,
       ]);

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -14,8 +14,32 @@ export const sanitizeString = (value: unknown): string =>
 const collapseWhitespace = (value: string) => value.replace(/\s+/g, '');
 
 export const sanitizeAppPassword = (value: unknown): string => {
-  const sanitized = sanitizeString(value);
-  return collapseWhitespace(sanitized);
+  const trimmed = sanitizeString(value);
+
+  if (!trimmed) {
+    return '';
+  }
+
+  const collapsed = collapseWhitespace(trimmed);
+
+  if (collapsed === trimmed) {
+    return trimmed;
+  }
+
+  const looksLikeGmailAppPassword =
+    /^[a-zA-Z0-9\s]+$/.test(trimmed) && collapsed.length === 16 && trimmed.length > collapsed.length;
+
+  if (looksLikeGmailAppPassword) {
+    return collapsed;
+  }
+
+  const shouldStripWhitespace = sanitizeString(process.env.NODEMAILER_STRIP_PASSWORD_WHITESPACE);
+
+  if (shouldStripWhitespace && ['true', '1', 'yes', 'on'].includes(shouldStripWhitespace.toLowerCase())) {
+    return collapsed;
+  }
+
+  return trimmed;
 };
 
 export const normalizeEmailAddress = (value: unknown): NormalizedEmail | null => {


### PR DESCRIPTION
## Summary
- update nodemailer password sanitization to preserve intentional whitespace
- keep Gmail-style passwords working by stripping spacing heuristically
- add opt-in environment flag to force whitespace removal when needed

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f8046d1cd4832eb83a2759ec465d4f