### PR TITLE
Handle prompt email failure gracefully

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -49,13 +49,17 @@ export async function POST(request: Request) {
 
     // Jika verifikasi Turnstile berhasil, lanjutkan mengirim email
     // Konfigurasi Gmail (gunakan app password, bukan password biasa)
-    let transporter;
-    let nodemailerUser;
+    let transporter: Awaited<ReturnType<typeof createEmailTransporter>>['transporter'];
+    let nodemailerUser: string;
+    let previewResolver:
+      | Awaited<ReturnType<typeof createEmailTransporter>>['getTestMessageUrl']
+      | undefined;
 
     try {
-      const emailTransport = createEmailTransporter();
+      const emailTransport = await createEmailTransporter();
       transporter = emailTransport.transporter;
       nodemailerUser = emailTransport.nodemailerUser;
+      previewResolver = emailTransport.getTestMessageUrl;
     } catch (error) {
       console.error('Konfigurasi Nodemailer belum lengkap:', error);
       return NextResponse.json(
@@ -78,7 +82,7 @@ export async function POST(request: Request) {
       );
     }
 
-    await transporter.sendMail({
+    const info = await transporter.sendMail({
       from: senderAddress,
       to: recipients.join(', '),
       replyTo: email,
@@ -92,6 +96,11 @@ export async function POST(request: Request) {
         <p>${message.replace(/\n/g, '<br>')}</p>
       `,
     });
+
+    const previewUrl = previewResolver?.(info);
+    if (typeof previewUrl === 'string' && previewUrl.length > 0) {
+      console.info('Preview email formulir kontak tersedia di:', previewUrl);
+    }
 
     return NextResponse.json({ message: 'Pesan Anda telah berhasil dikirim!' }, { status: 200 });
 

--- a/app/api/submit-article/route.ts
+++ b/app/api/submit-article/route.ts
@@ -84,13 +84,17 @@ export async function POST(request: Request) {
       );
     }
 
-    let transporter;
-    let nodemailerUser;
+    let transporter: Awaited<ReturnType<typeof createEmailTransporter>>['transporter'];
+    let nodemailerUser: string;
+    let previewResolver:
+      | Awaited<ReturnType<typeof createEmailTransporter>>['getTestMessageUrl']
+      | undefined;
 
     try {
-      const emailTransport = createEmailTransporter();
+      const emailTransport = await createEmailTransporter();
       transporter = emailTransport.transporter;
       nodemailerUser = emailTransport.nodemailerUser;
+      previewResolver = emailTransport.getTestMessageUrl;
     } catch (error) {
       console.error('Konfigurasi email belum lengkap untuk submission artikel.', error);
       return NextResponse.json(
@@ -142,7 +146,12 @@ export async function POST(request: Request) {
       html,
     };
 
-    await transporter.sendMail(mailOptions);
+    const info = await transporter.sendMail(mailOptions);
+
+    const previewUrl = previewResolver?.(info);
+    if (typeof previewUrl === 'string' && previewUrl.length > 0) {
+      console.info('Preview email submission artikel tersedia di:', previewUrl);
+    }
 
     return NextResponse.json({ message: 'Artikel berhasil dikirim!' }, { status: 200 });
   } catch (error: unknown) {

--- a/app/api/submit-prompt/route.ts
+++ b/app/api/submit-prompt/route.ts
@@ -138,6 +138,9 @@ export async function POST(request: Request) {
       date,
     });
 
+    let emailStatus: 'skipped' | 'sent' | 'failed' = skipEmail ? 'skipped' : 'sent';
+    let emailError: string | undefined;
+
     if (!skipEmail) {
       let transporter;
       let nodemailerUser;
@@ -212,7 +215,27 @@ export async function POST(request: Request) {
         `,
       };
 
-      await transporter.sendMail(mailOptions);
+      try {
+        await transporter.sendMail(mailOptions);
+        emailStatus = 'sent';
+      } catch (error: unknown) {
+        emailStatus = 'failed';
+
+        const errorMessage = (() => {
+          if (error && typeof error === 'object' && 'code' in error) {
+            const code = (error as { code?: unknown }).code;
+
+            if (code === 'EAUTH') {
+              return 'Konfigurasi kredensial email tidak valid.';
+            }
+          }
+
+          return 'Gagal mengirim email notifikasi prompt.';
+        })();
+
+        emailError = errorMessage;
+        console.error('Gagal mengirim email notifikasi prompt:', error);
+      }
     }
 
     if (persisted) {
@@ -221,13 +244,17 @@ export async function POST(request: Request) {
     }
 
     const successMessage = persisted
-      ? skipEmail
+      ? emailStatus === 'failed'
+        ? 'Prompt berhasil dikirim, namun notifikasi email gagal dikirim.'
+        : skipEmail
         ? 'Prompt berhasil dikirim dan langsung ditayangkan di katalog.'
         : 'Prompt berhasil dikirim!'
-      : 'Prompt berhasil dikirim, namun diperlukan peninjauan manual sebelum dipublikasikan.';
+      : emailStatus === 'failed'
+        ? 'Prompt berhasil dikirim, namun notifikasi email gagal dikirim. Prompt memerlukan peninjauan manual sebelum dipublikasikan.'
+        : 'Prompt berhasil dikirim, namun diperlukan peninjauan manual sebelum dipublikasikan.';
 
     return NextResponse.json(
-      { message: successMessage, prompt, persisted },
+      { message: successMessage, prompt, persisted, emailStatus, emailError },
       { status: 200 },
     );
 

--- a/app/api/umkm-submission/route.ts
+++ b/app/api/umkm-submission/route.ts
@@ -134,13 +134,17 @@ export async function POST(request: Request) {
       );
     }
 
-    let transporter;
-    let nodemailerUser;
+    let transporter: Awaited<ReturnType<typeof createEmailTransporter>>['transporter'];
+    let nodemailerUser: string;
+    let previewResolver:
+      | Awaited<ReturnType<typeof createEmailTransporter>>['getTestMessageUrl']
+      | undefined;
 
     try {
-      const emailTransport = createEmailTransporter();
+      const emailTransport = await createEmailTransporter();
       transporter = emailTransport.transporter;
       nodemailerUser = emailTransport.nodemailerUser;
+      previewResolver = emailTransport.getTestMessageUrl;
     } catch (error) {
       console.error('Konfigurasi email belum lengkap.', error);
       return NextResponse.json(
@@ -224,7 +228,7 @@ export async function POST(request: Request) {
     ]);
     const replyToAddress = replyToCandidates[0];
 
-    await transporter.sendMail({
+    const info = await transporter.sendMail({
       from: senderAddress,
       to: recipients.join(', '),
       ...(replyToAddress ? { replyTo: replyToAddress } : {}),
@@ -234,6 +238,11 @@ export async function POST(request: Request) {
         ${messageLines.join('\n')}
       `,
     });
+
+    const previewUrl = previewResolver?.(info);
+    if (typeof previewUrl === 'string' && previewUrl.length > 0) {
+      console.info('Preview email pengajuan UMKM tersedia di:', previewUrl);
+    }
 
     return NextResponse.json({
       message: 'Terima kasih! Data UMKM Anda sudah kami terima. Tim kami akan segera menindaklanjuti.',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "dotenv -e .env.local -- next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:email": "rm -rf .tests-tmp && pnpm exec tsc --module commonjs --target ES2020 --moduleResolution node --esModuleInterop --skipLibCheck --outDir .tests-tmp tests/email-smoke.ts lib/email.ts && NODEMAILER_USE_ETHEREAL=true node .tests-tmp/tests/email-smoke.js && rm -rf .tests-tmp"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",

--- a/tests/email-smoke.ts
+++ b/tests/email-smoke.ts
@@ -1,0 +1,61 @@
+import {
+  createEmailTransporter,
+  sanitizeEmailAddresses,
+  sanitizeSenderAddress,
+  sanitizeString,
+} from '../lib/email';
+
+const TARGET_EMAIL = 'ayicktigabelas@gmail.com';
+
+async function main() {
+  if (!process.env.NODEMAILER_USE_ETHEREAL) {
+    process.env.NODEMAILER_USE_ETHEREAL = 'true';
+  }
+
+  const { transporter, nodemailerUser, getTestMessageUrl, testAccount } = await createEmailTransporter();
+
+  const senderAddress = sanitizeSenderAddress(
+    sanitizeString(process.env.NODEMAILER_FROM) || `"RuangRiung" <${nodemailerUser}>`,
+    nodemailerUser,
+  );
+
+  const recipients = sanitizeEmailAddresses([
+    TARGET_EMAIL,
+    nodemailerUser,
+  ]);
+
+  if (recipients.length === 0) {
+    throw new Error('Tidak ada penerima yang valid untuk pengujian.');
+  }
+
+  const info = await transporter.sendMail({
+    from: senderAddress,
+    to: recipients.join(', '),
+    subject: 'Tes Pengiriman Notifikasi Prompt',
+    text: 'Ini adalah email percobaan untuk memastikan konfigurasi pengiriman notifikasi prompt bekerja dengan benar.',
+    html: `
+      <h2>Pengujian Pengiriman Email Prompt</h2>
+      <p>Email ini dikirim sebagai bagian dari pengujian otomatis.</p>
+      <p>Jika Anda membaca ini di inbox Ethereal, silakan gunakan tautan preview di bawah.</p>
+    `,
+  });
+
+  const previewUrl = getTestMessageUrl?.(info);
+
+  console.log('Email percobaan berhasil dikirim.');
+  console.log('Pengirim:', senderAddress);
+  console.log('Penerima:', recipients.join(', '));
+
+  if (testAccount?.web) {
+    console.log('Kotak masuk Ethereal:', testAccount.web);
+  }
+
+  if (previewUrl) {
+    console.log('Preview URL:', previewUrl);
+  }
+}
+
+main().catch(error => {
+  console.error('Gagal menjalankan pengujian email:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- keep prompt submissions responsive when email delivery fails
- report email failure details in the API response with user-friendly messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f81379fc90832ebdc58579d5d4ffd0