### PR TITLE
Restore stable contact email handling

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -50,16 +50,12 @@ export async function POST(request: Request) {
     // Jika verifikasi Turnstile berhasil, lanjutkan mengirim email
     // Konfigurasi Gmail (gunakan app password, bukan password biasa)
     let transporter: Awaited<ReturnType<typeof createEmailTransporter>>['transporter'];
-    let nodemailerUser: string;
-    let previewResolver:
-      | Awaited<ReturnType<typeof createEmailTransporter>>['getTestMessageUrl']
-      | undefined;
+    let nodemailerUser: Awaited<ReturnType<typeof createEmailTransporter>>['nodemailerUser'];
 
     try {
       const emailTransport = await createEmailTransporter();
       transporter = emailTransport.transporter;
       nodemailerUser = emailTransport.nodemailerUser;
-      previewResolver = emailTransport.getTestMessageUrl;
     } catch (error) {
       console.error('Konfigurasi Nodemailer belum lengkap:', error);
       return NextResponse.json(
@@ -82,7 +78,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const info = await transporter.sendMail({
+    await transporter.sendMail({
       from: senderAddress,
       to: recipients.join(', '),
       replyTo: email,
@@ -96,11 +92,6 @@ export async function POST(request: Request) {
         <p>${message.replace(/\n/g, '<br>')}</p>
       `,
     });
-
-    const previewUrl = previewResolver?.(info);
-    if (typeof previewUrl === 'string' && previewUrl.length > 0) {
-      console.info('Preview email formulir kontak tersedia di:', previewUrl);
-    }
 
     return NextResponse.json({ message: 'Pesan Anda telah berhasil dikirim!' }, { status: 200 });
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -269,7 +269,7 @@ const createEtherealTransporter = async (): Promise<EmailTransporterResult> => {
 
 export const createEmailTransporter = async (): Promise<EmailTransporterResult> => {
   const nodemailerUser = sanitizeEmail(resolveMailEnvValue('NODEMAILER_EMAIL'));
-  const nodemailerPass = sanitizeAppPassword(resolveMailEnvValue('NODEMAILER_APP_PASSWORD'));
+  const nodemailerPass = sanitizeString(resolveMailEnvValue('NODEMAILER_APP_PASSWORD'));
 
   if (nodemailerUser && nodemailerPass) {
     const transportOptions = createTransportOptions(nodemailerUser, nodemailerPass);


### PR DESCRIPTION
## Summary
- revert the contact form email flow to the previously stable sendMail usage
- simplify transporter initialization so it mirrors the behaviour from commit 9a5a25d
- return to trimmed app password handling to match the prior working configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f820ca1528832e9761ed1840aadd2c