### PR TITLE
Fix Gmail app password sanitization for Nodemailer

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -269,7 +269,7 @@ const createEtherealTransporter = async (): Promise<EmailTransporterResult> => {
 
 export const createEmailTransporter = async (): Promise<EmailTransporterResult> => {
   const nodemailerUser = sanitizeEmail(resolveMailEnvValue('NODEMAILER_EMAIL'));
-  const nodemailerPass = sanitizeString(resolveMailEnvValue('NODEMAILER_APP_PASSWORD'));
+  const nodemailerPass = sanitizeAppPassword(resolveMailEnvValue('NODEMAILER_APP_PASSWORD'));
 
   if (nodemailerUser && nodemailerPass) {
     const transportOptions = createTransportOptions(nodemailerUser, nodemailerPass);


### PR DESCRIPTION
## Summary
- use the existing sanitizeAppPassword helper when resolving the Nodemailer app password
- ensure Gmail-style app passwords copied with spaces are normalized before authentication

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f824b29e8c832ea01ccd9936b388da