### PR TITLE
Add Google AdSense banner to homepage

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -29,6 +29,7 @@ import { useState, useEffect, useRef } from 'react';
 import FAQ from '@/components/FAQ';
 import Link from 'next/link';
 import PromptSubmissionTrigger from '@/components/PromptSubmissionTrigger';
+import GoogleAd from '@/components/GoogleAd';
 
 interface HomeClientProps {
   latestArticle: {
@@ -364,6 +365,8 @@ export default function HomeClient({ latestArticle }: HomeClientProps) {
       <main className="w-full flex flex-col items-center">
         <Tabs />
       </main>
+
+      <GoogleAd className="w-full max-w-4xl my-8" />
 
       <div className="w-full max-w-4xl mt-10 mb-6">
         <Link

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -88,6 +88,13 @@ export default function RootLayout({
             `,
           }}
         />
+        <Script
+          id="google-adsense-script"
+          async
+          strategy="afterInteractive"
+          crossOrigin="anonymous"
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6394253519537490"
+        />
       </body>
     </html>
   );

--- a/components/GoogleAd.tsx
+++ b/components/GoogleAd.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+
+declare global {
+  interface Window {
+    adsbygoogle?: unknown[];
+  }
+}
+
+interface GoogleAdProps {
+  className?: string;
+}
+
+export default function GoogleAd({ className }: GoogleAdProps) {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (error) {
+      console.error('AdSense initialization error', error);
+    }
+  }, []);
+
+  return (
+    <div className={className}>
+      <ins
+        className="adsbygoogle"
+        style={{ display: 'block' }}
+        data-ad-client="ca-pub-6394253519537490"
+        data-ad-slot="1809562266"
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- load the Google AdSense script once through the application layout
- add a reusable GoogleAd component that renders the provided ad slot
- place the ad unit in the homepage content flow for visibility

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690012456bb4832e97c14a4e7dd3f621