### PR TITLE
Add tags for coloring myself prompt

### DIFF
--- a/content/prompts/prompt-206.md
+++ b/content/prompts/prompt-206.md
@@ -1,0 +1,15 @@
+---
+id: "206"
+slug: "coloring-myself"
+title: "Coloring myself"
+author: "Rida Lukman"
+date: "2025-11-02"
+tool: "Dall E-3"
+tags:
+  - surreal
+  - pixel-art
+  - glitch
+  - hyperrealism
+---
+
+surreal hyperrealistic depiction of a woman in a jester gown, monochrome pixel-art aesthetic, holding a paintbrush in one hand and a paint palette in the other, painting her own lips; floating pixel blocks in the background, glitch distortions, fragmented playing cards pixelizing and breaking apart, eerie digital atmosphere; pure monochrome tones except for the lips, paint palette, wet paint strokes, and brush tip which are vivid in color; pixelated texture, subtle scanline effect, dreamlike yet unsettling mood


### PR DESCRIPTION
## Summary
- add a set of relevant tags to the "Coloring myself" prompt entry to describe its themes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_69070b80f720832ebe1b208aec8fa532