### PR TITLE
Re-enable Google AdSense slot rendering

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -88,13 +88,13 @@ export default function RootLayout({
             `,
           }}
         />
-        {/* <Script
+        <Script
           id="google-adsense-script"
           async
           strategy="afterInteractive"
           crossOrigin="anonymous"
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6394253519537490"
-        /> */}
+        />
       </body>
     </html>
   );

--- a/components/GoogleAd.tsx
+++ b/components/GoogleAd.tsx
@@ -13,29 +13,28 @@ interface GoogleAdProps {
 }
 
 export default function GoogleAd({ className }: GoogleAdProps) {
-  // useEffect(() => {
-  //   if (typeof window === 'undefined') {
-  //     return;
-  //   }
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
 
-  //   try {
-  //     (window.adsbygoogle = window.adsbygoogle || []).push({});
-  //   } catch (error) {
-  //     console.error('AdSense initialization error', error);
-  //   }
-  // }, []);
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (error) {
+      console.error('AdSense initialization error', error);
+    }
+  }, []);
 
-  return null;
-  // return (
-  //   <div className={className}>
-  //     <ins
-  //       className="adsbygoogle"
-  //       style={{ display: 'block' }}
-  //       data-ad-client="ca-pub-6394253519537490"
-  //       data-ad-slot="1809562266"
-  //       data-ad-format="auto"
-  //       data-full-width-responsive="true"
-  //     />
-  //   </div>
-  // );
+  return (
+    <div className={className}>
+      <ins
+        className="adsbygoogle"
+        style={{ display: 'block' }}
+        data-ad-client="ca-pub-6394253519537490"
+        data-ad-slot="1809562266"
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
### Motivation
- Re-introduce AdSense ad slots so the site can serve Google ads where previously disabled. 

### Description
- Restored the global AdSense loader script in `app/layout.tsx` so the AdSense library is loaded after hydration via a `<Script>` tag.
- Restored `components/GoogleAd.tsx` to render the `<ins className="adsbygoogle">` ad unit and call `(window.adsbygoogle = window.adsbygoogle || []).push({})` inside `useEffect` on mount.
- Preserved the existing `data-ad-client` (`ca-pub-6394253519537490`) and `data-ad-slot` (`1809562266`) attributes used by the ad unit.

### Testing
- Ran `npm run build` and the project compiled and completed static page generation successfully.
- Ran `npx next lint` / `npm run lint` and it failed in this environment with `Invalid project directory provided, no such directory: /workspace/ruangriung-generator-app/lint` (lint error unrelated to the changes in ad code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf53e5df20832eb1906031128c780b)